### PR TITLE
fix: ⚡️ use nft.storage directory API

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { NFTStorage } from "nft.storage";
+import { File, NFTStorage } from "nft.storage";
 import { packToBlob } from "ipfs-car/pack/blob";
 import { MemoryBlockStore } from "ipfs-car/blockstore/memory";
 import express from "express";
@@ -45,7 +45,7 @@ app.post("/multiple", upload.array("assets", 100), async function (req, res) {
       return;
     }
     const cid = await client.storeDirectory(req.files.map((file) => (
-      new Blob(file.buffer)
+      new File([file.buffer], file.originalname)
       )));
 
     res.json({ cid:cid.toString() });

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -14,7 +14,7 @@ const app = express();
 app.use(cors());
 
 const storage = multer.memoryStorage();
-const upload = multer({ storage });
+const upload = multer({ storage, preservePath: true });
 
 app.post("/single", upload.single("asset"), async function (req, res) {
   try {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -33,7 +33,7 @@ app.post("/single", upload.single("asset"), async function (req, res) {
 
     res.json({ cid });
   } catch (err) {
-    console.log("unexpected error calling /single endpoint", err);
+    console.error("unexpected error calling /single endpoint", err);
     res.status(500).send("unexpected error");
   }
 });
@@ -44,20 +44,13 @@ app.post("/multiple", upload.array("assets", 100), async function (req, res) {
       res.status(400).send("Invalid request");
       return;
     }
-    const { root, car } = await packToBlob({
-      input: req.files.map((file) => ({
-        path: file.originalname,
-        content: file.buffer,
-      })),
-      blockstore: new MemoryBlockStore(),
-      wrapWithDirectory: true,
-    });
+    const cid = await client.storeDirectory(req.files.map((file) => (
+      new Blob(file.buffer)
+      )));
 
-    await client.storeCar(car);
-    const cid = root.toV0().toString();
-    res.json({ cid });
+    res.json({ cid:cid.toString() });
   } catch (err) {
-    console.log("unexpected error calling /multiple endpoint", err);
+    console.error("unexpected error calling /multiple endpoint", err);
     res.status(500).send("unexpected error");
   }
 });


### PR DESCRIPTION
To get subfolders to work we need to use NFT.storage's API.

The current version flattens subfolders:
![image](https://user-images.githubusercontent.com/7041726/184397081-11c10877-1344-4cbc-9c99-30b1ed9a3f5f.png)

The PR do not work yet, I'm not sure to understand exactly what is expected by [storeDirectory](https://nftstorage.github.io/nft.storage/client/classes/lib.NFTStorage.html#storeDirectory) from nodejs.
