### PR TITLE
Feat add local ipfs upload

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,9 @@
+FILE_DATASTORE_PATH=/data/datastore
+FILE_BLOCKSTORE_PATH=/data/blockstore
+FILE_SIZE_LIMIT=2000000000
+USE_NFTSTORAGE=true
+API_TOKEN=somenftstoragetoken
+NODE_ENV=production
+DEBUG=express:*
+IPFS_PROFILE=server
+IPFS_SERVER=ipfs

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,3 @@
-FILE_DATASTORE_PATH=/data/datastore
-FILE_BLOCKSTORE_PATH=/data/blockstore
 FILE_SIZE_LIMIT=2000000000
 USE_NFTSTORAGE=true
 API_TOKEN=somenftstoragetoken

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules/
+data/

--- a/001-init.sh
+++ b/001-init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -ex
+# Add Teia's IPFS node
+ipfs bootstrap add /dnsaddr/ipfs.teia.art/p2p/12D3KooWP84PmvN2ncA2vDCzoea2DGgBsEgxRreiMWpvZdpEgtrq
+(sleep 5 && ipfs swarm peering add /p2p/12D3KooWP84PmvN2ncA2vDCzoea2DGgBsEgxRreiMWpvZdpEgtrq)&
+(sleep 5 && ipfs swarm connect /p2p/12D3KooWP84PmvN2ncA2vDCzoea2DGgBsEgxRreiMWpvZdpEgtrq)&

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:21
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+RUN npm i
+
+CMD [ "npm", "run", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  ipfsproxy:
+    build: .
+    restart: unless-stopped
+    ports:
+      - 0.0.0.0:4444:4444
+    env_file:
+      - .env
+    volumes:
+      - data:/usr/src/app/data
+
+  ipfs:
+    image: ipfs/kubo:v0.28.0
+    env_file:
+      - .env
+    volumes:
+      - ipfs:/data/ipfs
+      - ./001-init.sh:/container-init.d/001-init.sh
+
+volumes:
+  data:
+  ipfs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
 
   ipfs:
     image: ipfs/kubo:v0.28.0
+    restart: unless-stopped
     env_file:
       - .env
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
-        "dotenv": "^16.0.1",
-        "express": "^4.18.1",
-        "ipfs-car": "^0.7.0",
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2",
+        "ipfs-car": "^1.2.0",
         "multer": "^1.4.5-lts.1",
-        "nanoid": "^4.0.0",
-        "nft.storage": "^6.4.1"
+        "nanoid": "^5.0.7",
+        "nft.storage": "^7.1.1"
       },
       "devDependencies": {
-        "prettier": "^2.7.1"
+        "prettier": "^3.2.5"
       },
       "engines": {
         "node": ">=16"
@@ -89,11 +89,118 @@
         "multiformats": "^9.5.4"
       }
     },
+    "node_modules/@ipld/dag-json": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.2.0.tgz",
+      "integrity": "sha512-O9YLUrl3d3WbVz7v1WkajFkyfOLEe2Fep+wor4fgVe0ywxzrivrj437NiPcVyB+2EDdFn/Q7tCHFf8YVhDf8ZA==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-json/node_modules/cborg": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+      "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/@ipld/dag-json/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
     "node_modules/@ipld/dag-pb": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.17.tgz",
       "integrity": "sha512-AmzOdmdv5hT8iGsrbpzm5R0Fvk7DEbtwcglG2gJLvW9q3zwb+E681hY4EwEELypM1Rfnp/JDA9dGqYcpEi/iAg==",
       "dependencies": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/unixfs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-3.0.0.tgz",
+      "integrity": "sha512-Tj3/BPOlnemcZQ2ETIZAO8hqAs9KNzWyX5J9+JCL9jDwvYwjxeYjqJ3v+9DusNvTBmJhZnGVP6ijUHrsuOLp+g==",
+      "dependencies": {
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.1.3",
+        "@perma/map": "^1.0.2",
+        "actor": "^2.3.1",
+        "multiformats": "^13.0.1",
+        "protobufjs": "^7.1.2",
+        "rabin-rs": "^2.1.0"
+      }
+    },
+    "node_modules/@ipld/unixfs/node_modules/@ipld/dag-pb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
+      "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
+      "dependencies": {
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/unixfs/node_modules/@multiformats/murmur3": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
+      "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+      "dependencies": {
+        "multiformats": "^13.0.0",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/unixfs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/@ipld/unixfs/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/@ipld/unixfs/node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@multiformats/blake2": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
+      "integrity": "sha512-T1Kzya0wjj85CaVeRSpJ858EnSvW1pw94GSitxYf84VsNdv5XYbJ6QG8y26Ft1bVALzrUCmqkQrR53QHSyu6RA==",
+      "dependencies": {
+        "blakejs": "^1.1.1",
         "multiformats": "^9.5.4"
       }
     },
@@ -105,6 +212,42 @@
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
       }
+    },
+    "node_modules/@multiformats/sha3": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.17.tgz",
+      "integrity": "sha512-7ik6pk178qLO2cpNucgf48UnAOBMkq/2H92DP4SprZOJqM9zqbVaKS7XyYW6UvhRsDJ3wi921fYv1ihTtQHLtA==",
+      "dependencies": {
+        "js-sha3": "^0.8.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@perma/map": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@perma/map/-/map-1.0.3.tgz",
+      "integrity": "sha512-Bf5njk0fnJGTFE2ETntq0N1oJ6YdCPIpTDn3R3KYZJQdeYSOCNL7mBrFlGnbqav8YQhJA/p81pvHINX9vAtHkQ==",
+      "dependencies": {
+        "@multiformats/murmur3": "^2.1.0",
+        "murmurhash3js-revisited": "^3.0.0"
+      }
+    },
+    "node_modules/@perma/map/node_modules/@multiformats/murmur3": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
+      "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+      "dependencies": {
+        "multiformats": "^13.0.0",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@perma/map/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -200,17 +343,29 @@
       }
     },
     "node_modules/@web-std/fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.3.tgz",
-      "integrity": "sha512-PtaKr6qvw2AmKChugzhQWuTa12dpbogHRBxwcleAZ35UhWucnfD4N+g3f7qYK2OeioSWTK3yMf6n/kOOfqxHaQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-4.2.1.tgz",
+      "integrity": "sha512-M6sgHDgKegcjuVsq8J6jb/4XvhPGui8uwp3EIoADGXUnBl9vKzKLk9H9iFzrPJ6fSV6zZzFWXPyziBJp9hxzBA==",
       "dependencies": {
         "@web-std/blob": "^3.0.3",
+        "@web-std/file": "^3.0.2",
         "@web-std/form-data": "^3.0.2",
+        "@web-std/stream": "^1.0.1",
         "@web3-storage/multipart-parser": "^1.0.0",
-        "data-uri-to-buffer": "^3.0.1"
+        "abort-controller": "^3.0.0",
+        "data-uri-to-buffer": "^3.0.1",
+        "mrmime": "^1.0.0"
       },
       "engines": {
         "node": "^10.17 || >=12.3"
+      }
+    },
+    "node_modules/@web-std/fetch/node_modules/@web-std/stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.3.tgz",
+      "integrity": "sha512-5MIngxWyq4rQiGoDAC2WhjLuDraW8+ff2LD2et4NRY933K3gL8CHlUXrh8ZZ3dC9A9Xaub8c9sl5exOJE58D9Q==",
+      "dependencies": {
+        "web-streams-polyfill": "^3.1.1"
       }
     },
     "node_modules/@web-std/file": {
@@ -222,9 +377,9 @@
       }
     },
     "node_modules/@web-std/form-data": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-3.0.2.tgz",
-      "integrity": "sha512-rhc8IRw66sJ0FHcnC84kT3mTN6eACTuNftkt1XSl1Ef6WRKq4Pz65xixxqZymAZl1K3USpwhLci4SKNn4PYxWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-3.1.0.tgz",
+      "integrity": "sha512-WkOrB8rnc2hEK2iVhDl9TFiPMptmxJA1HaIzSdc2/qk3XS4Ny4cCt6/V36U3XmoYKz0Md2YyK2uOZecoZWPAcA==",
       "dependencies": {
         "web-encoding": "1.1.5"
       }
@@ -236,6 +391,23 @@
       "dependencies": {
         "web-streams-polyfill": "^3.1.1"
       }
+    },
+    "node_modules/@web3-storage/car-block-validator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.0.tgz",
+      "integrity": "sha512-KKQ/M5WtpH/JlkX+bQYKzdG4azmSF495T7vpewje2xh7MBh1d94/BLblxCcLM/larWvXDxOkbAyTTdlECAAuUw==",
+      "dependencies": {
+        "@multiformats/blake2": "^1.0.13",
+        "@multiformats/murmur3": "^1.1.3",
+        "@multiformats/sha3": "^2.0.15",
+        "multiformats": "9.9.0",
+        "uint8arrays": "^3.1.1"
+      }
+    },
+    "node_modules/@web3-storage/car-block-validator/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
@@ -270,6 +442,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/actor": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/actor/-/actor-2.3.1.tgz",
+      "integrity": "sha512-ST/3wnvcP2tKDXnum7nLCLXm+/rsf8vPocXH2Fre6D8FQwNkGDd4JEitBlXj007VQJfiGYRQvXqwOBZVi+JtRg=="
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -367,6 +544,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
     "node_modules/blob-to-it": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
@@ -391,20 +573,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
-        "raw-body": "2.5.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -586,17 +768,17 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -731,11 +913,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {
@@ -875,17 +1060,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
     "node_modules/express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -901,7 +1091,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -920,6 +1110,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
       "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+    },
+    "node_modules/files-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.0.4.tgz",
+      "integrity": "sha512-sMNIVdpRh1uCSIaat3qnM3E6aA1C5FVn5/B16z8sN3gIMjZPkxtVCorkEL07xTcCIxVwTXzjU1Ota7Wif6RfQQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",
@@ -1036,6 +1237,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/hamt-sharding": {
       "version": "2.0.1",
@@ -1263,35 +1469,199 @@
       }
     },
     "node_modules/ipfs-car": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.7.0.tgz",
-      "integrity": "sha512-9ser6WWZ1ZMTCGbcVkRXUzOrpQ4SIiLfzIEnk+3LQsXbV09yeZg3ijhRuEXozEIYE68Go9JmOFshamsK9iKlNQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-1.2.0.tgz",
+      "integrity": "sha512-A++1UesxqwfNv14NmFxr4MHi+vD9rR6SWr87MU9o0315Mzqys48pEefL8rlCAA9cw2qKYeT/ZPYVtqIMAr6U1Q==",
       "dependencies": {
-        "@ipld/car": "^3.2.3",
-        "@web-std/blob": "^3.0.1",
-        "bl": "^5.0.0",
-        "blockstore-core": "^1.0.2",
-        "browser-readablestream-to-it": "^1.0.2",
-        "idb-keyval": "^6.0.3",
-        "interface-blockstore": "^2.0.2",
-        "ipfs-core-types": "^0.8.3",
-        "ipfs-core-utils": "^0.12.1",
-        "ipfs-unixfs-exporter": "^7.0.4",
-        "ipfs-unixfs-importer": "^9.0.4",
-        "ipfs-utils": "^9.0.2",
-        "it-all": "^1.0.5",
-        "it-last": "^1.0.5",
-        "it-pipe": "^1.1.0",
-        "meow": "^9.0.0",
-        "move-file": "^2.1.0",
-        "multiformats": "^9.6.3",
-        "stream-to-it": "^0.2.3",
-        "streaming-iterables": "^6.0.0",
-        "uint8arrays": "^3.0.0"
+        "@ipld/car": "^5.1.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.1",
+        "@ipld/dag-pb": "^4.0.2",
+        "@ipld/unixfs": "^3.0.0",
+        "@web3-storage/car-block-validator": "^1.0.1",
+        "files-from-path": "^1.0.0",
+        "ipfs-unixfs-exporter": "^13.0.1",
+        "multiformats": "^13.0.1",
+        "sade": "^1.8.1",
+        "varint": "^6.0.0"
       },
       "bin": {
-        "🚘": "dist/cjs/cli/cli.js",
-        "ipfs-car": "dist/cjs/cli/cli.js"
+        "🚘": "bin.js",
+        "ipfs-car": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/@ipld/car": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.3.0.tgz",
+      "integrity": "sha512-OB8LVvJeVAFFGluNIkZeDZ/aGeoekFKsuIvNT9I5sJIb5WekQuW5+lekjQ7Z7mZ7DBKuke/kI4jBT1j0/akU1w==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.7",
+        "cborg": "^4.0.5",
+        "multiformats": "^13.0.0",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/@ipld/dag-cbor": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+      "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/@ipld/dag-pb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
+      "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
+      "dependencies": {
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/@multiformats/murmur3": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
+      "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+      "dependencies": {
+        "multiformats": "^13.0.0",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/cborg": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+      "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/hamt-sharding": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.6.tgz",
+      "integrity": "sha512-nZeamxfymIWLpVcAN0CRrb7uVq3hCOGj9IcL6NMA6VVCVWqj+h9Jo/SmaWuS92AEDf1thmHsM5D5c70hM3j2Tg==",
+      "dependencies": {
+        "sparse-array": "^1.3.1",
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/interface-blockstore": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.10.tgz",
+      "integrity": "sha512-9K48hTvBCGsKVD3pF4ILgDcf+W2P/gq0oxLcsHGB6E6W6nDutYkzR+7k7bCs9REHrBEfKzcVDEKieiuNM9WRZg==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "multiformats": "^13.0.1"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/interface-store": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
+      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
+    },
+    "node_modules/ipfs-car/node_modules/ipfs-unixfs": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.4.tgz",
+      "integrity": "sha512-RE4nyx5qgG2w7JOLj0Y0D7SfAR1ZkEdramNaBx0OSD4DlQ2Y2NORgc4FHfej3Pgy31v+QISDVP1pQJhdv3bUUg==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/ipfs-unixfs-exporter": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-13.5.0.tgz",
+      "integrity": "sha512-s1eWXzoyhQFNEAB1p+QE3adjhW+lBdgpORmmjiCLiruHs5z7T5zsAgRVcWpM8LWYhq2flRtJHObb7Hg73J+oLQ==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.1.7",
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.0.0",
+        "err-code": "^3.0.1",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^5.0.0",
+        "ipfs-unixfs": "^11.0.0",
+        "it-filter": "^3.0.2",
+        "it-last": "^3.0.2",
+        "it-map": "^3.0.3",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^13.0.0",
+        "p-queue": "^8.0.1",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/it-filter": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.4.tgz",
+      "integrity": "sha512-e0sz+st4sudK/zH6GZ/gRTRP8A/ADuJFCYDmRgMbZvR79y5+v4ZXav850bBZk5wL9zXaYZFxS1v/6Qi+Vjwh5g==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/it-last": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.4.tgz",
+      "integrity": "sha512-Ns+KTsQWhs0KCvfv5X3Ck3lpoYxHcp4zUp4d+AOdmC8cXXqDuoZqAjfWhgCbxJubXyIYWdfE2nRcfWqgvZHP8Q=="
+    },
+    "node_modules/ipfs-car/node_modules/it-map": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.5.tgz",
+      "integrity": "sha512-hB0TDXo/h4KSJJDSRLgAPmDroiXP6Fx1ck4Bzl3US9hHfZweTKsuiP0y4gXuTMcJlS6vj0bb+f70rhkD47ZA3w==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/it-peekable": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.3.tgz",
+      "integrity": "sha512-Wx21JX/rMzTEl9flx3DGHuPV1KQFGOl8uoKfQtmZHgPQtGb89eQ6RyVd82h3HuP9Ghpt0WgBDlmmdWeHXqyx7w=="
+    },
+    "node_modules/ipfs-car/node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/ipfs-car/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/ipfs-core-types": {
@@ -1754,12 +2124,39 @@
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
       "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
     },
+    "node_modules/it-merge": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.3.tgz",
+      "integrity": "sha512-FYVU15KC5pb/GQX1Ims+lee8d4pdqGVCpWr0lkNj8o4xuNo7jY71k6GuEiWdP+T7W1bJqewSxX5yoTy5yZpRVA==",
+      "dependencies": {
+        "it-pushable": "^3.2.0"
+      }
+    },
+    "node_modules/it-parallel": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.6.tgz",
+      "integrity": "sha512-i7UM7I9LTkDJw3YIqXHFAPZX6CWYzGc+X3irdNrVExI4vPazrJdI7t5OqrSVN8CONXLAunCiqaSV/zZRbQR56A==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
     "node_modules/it-parallel-batch": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.10.tgz",
       "integrity": "sha512-3+4gW15xdf/BOx9zij0QVnB1bDGSLOTABlaVm7ebHH1S9gDUgd5aLNb0WsFXPTfKe104iC6lxdzfbMGh1B07rg==",
       "dependencies": {
         "it-batch": "^1.0.9"
+      }
+    },
+    "node_modules/it-parallel/node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/it-peekable": {
@@ -1771,6 +2168,34 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
       "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+    },
+    "node_modules/it-pushable": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/it-pushable/node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-take": {
       "version": "1.0.2",
@@ -1802,6 +2227,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2021,6 +2451,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2078,14 +2524,20 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/native-abort-controller": {
@@ -2113,14 +2565,14 @@
       }
     },
     "node_modules/nft.storage": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/nft.storage/-/nft.storage-6.4.1.tgz",
-      "integrity": "sha512-UwZ+QgDCr58X+vHN4BydqdB89M8Vaza+vkWR9RatC3rXuDfIyYE5T7oOV53tbiuhA8x5Yi56tlG3NI8wLfOO1A==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/nft.storage/-/nft.storage-7.1.1.tgz",
+      "integrity": "sha512-OHFeRiWLcGCWHX8Kx3yvSt7qGbHwEROl0kcN2xaHWBaR0ApYH5DnjlqczXSwP9WwBDtjhyDk4IHReXSwuZkB7Q==",
       "dependencies": {
         "@ipld/car": "^3.2.3",
         "@ipld/dag-cbor": "^6.0.13",
         "@web-std/blob": "^3.0.1",
-        "@web-std/fetch": "^3.0.3",
+        "@web-std/fetch": "^4.1.2",
         "@web-std/file": "^3.0.0",
         "@web-std/form-data": "^3.0.0",
         "carbites": "^1.0.6",
@@ -2282,6 +2734,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-queue": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
+      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -2292,6 +2759,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -2351,15 +2829,15 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -2370,10 +2848,19 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/progress-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
+      "integrity": "sha512-zIB6QDrSbPfRg+33FZalluFIowkbV5Xh1xSuetjG+rlC5he6u2dc6VQJ0TbMdlN3R1RHdpOqxEFMKTnQ+itUwA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2395,6 +2882,29 @@
         "pbts": "bin/pbts"
       }
     },
+    "node_modules/protons-runtime": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.4.0.tgz",
+      "integrity": "sha512-XfA++W/WlQOSyjUyuF5lgYBfXZUEMP01Oh1C2dSwZAlF2e/ZrMRPfWonXj6BGM+o8Xciv7w0tsRMKYwYEuQvaw==",
+      "dependencies": {
+        "uint8-varint": "^2.0.2",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/protons-runtime/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2408,9 +2918,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -2428,6 +2938,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/rabin-rs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rabin-rs/-/rabin-rs-2.1.0.tgz",
+      "integrity": "sha512-5y72gAXPzIBsAMHcpxZP8eMDuDT98qMP1BqSDHRbHkJJXEgWIN1lA47LxUqzsK6jknOJtgfkQr9v+7qMlFDm6g=="
     },
     "node_modules/rabin-wasm": {
       "version": "0.1.5",
@@ -2488,9 +3003,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -2564,9 +3079,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -2668,6 +3183,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/safari-14-idb-fix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
@@ -2698,9 +3224,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2966,10 +3492,53 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
+    "node_modules/uint8-varint": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/uint8-varint/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
+      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/uint8arrays": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -3178,11 +3747,103 @@
         "multiformats": "^9.5.4"
       }
     },
+    "@ipld/dag-json": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.2.0.tgz",
+      "integrity": "sha512-O9YLUrl3d3WbVz7v1WkajFkyfOLEe2Fep+wor4fgVe0ywxzrivrj437NiPcVyB+2EDdFn/Q7tCHFf8YVhDf8ZA==",
+      "requires": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "dependencies": {
+        "cborg": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+          "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA=="
+        },
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+        }
+      }
+    },
     "@ipld/dag-pb": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.17.tgz",
       "integrity": "sha512-AmzOdmdv5hT8iGsrbpzm5R0Fvk7DEbtwcglG2gJLvW9q3zwb+E681hY4EwEELypM1Rfnp/JDA9dGqYcpEi/iAg==",
       "requires": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@ipld/unixfs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-3.0.0.tgz",
+      "integrity": "sha512-Tj3/BPOlnemcZQ2ETIZAO8hqAs9KNzWyX5J9+JCL9jDwvYwjxeYjqJ3v+9DusNvTBmJhZnGVP6ijUHrsuOLp+g==",
+      "requires": {
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.1.3",
+        "@perma/map": "^1.0.2",
+        "actor": "^2.3.1",
+        "multiformats": "^13.0.1",
+        "protobufjs": "^7.1.2",
+        "rabin-rs": "^2.1.0"
+      },
+      "dependencies": {
+        "@ipld/dag-pb": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
+          "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
+          "requires": {
+            "multiformats": "^13.1.0"
+          }
+        },
+        "@multiformats/murmur3": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
+          "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+          "requires": {
+            "multiformats": "^13.0.0",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+        },
+        "protobufjs": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+          "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          }
+        }
+      }
+    },
+    "@multiformats/blake2": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
+      "integrity": "sha512-T1Kzya0wjj85CaVeRSpJ858EnSvW1pw94GSitxYf84VsNdv5XYbJ6QG8y26Ft1bVALzrUCmqkQrR53QHSyu6RA==",
+      "requires": {
+        "blakejs": "^1.1.1",
         "multiformats": "^9.5.4"
       }
     },
@@ -3193,6 +3854,40 @@
       "requires": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
+      }
+    },
+    "@multiformats/sha3": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.17.tgz",
+      "integrity": "sha512-7ik6pk178qLO2cpNucgf48UnAOBMkq/2H92DP4SprZOJqM9zqbVaKS7XyYW6UvhRsDJ3wi921fYv1ihTtQHLtA==",
+      "requires": {
+        "js-sha3": "^0.8.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@perma/map": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@perma/map/-/map-1.0.3.tgz",
+      "integrity": "sha512-Bf5njk0fnJGTFE2ETntq0N1oJ6YdCPIpTDn3R3KYZJQdeYSOCNL7mBrFlGnbqav8YQhJA/p81pvHINX9vAtHkQ==",
+      "requires": {
+        "@multiformats/murmur3": "^2.1.0",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "dependencies": {
+        "@multiformats/murmur3": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
+          "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+          "requires": {
+            "multiformats": "^13.0.0",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+        }
       }
     },
     "@protobufjs/aspromise": {
@@ -3289,14 +3984,28 @@
       }
     },
     "@web-std/fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.3.tgz",
-      "integrity": "sha512-PtaKr6qvw2AmKChugzhQWuTa12dpbogHRBxwcleAZ35UhWucnfD4N+g3f7qYK2OeioSWTK3yMf6n/kOOfqxHaQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-4.2.1.tgz",
+      "integrity": "sha512-M6sgHDgKegcjuVsq8J6jb/4XvhPGui8uwp3EIoADGXUnBl9vKzKLk9H9iFzrPJ6fSV6zZzFWXPyziBJp9hxzBA==",
       "requires": {
         "@web-std/blob": "^3.0.3",
+        "@web-std/file": "^3.0.2",
         "@web-std/form-data": "^3.0.2",
+        "@web-std/stream": "^1.0.1",
         "@web3-storage/multipart-parser": "^1.0.0",
-        "data-uri-to-buffer": "^3.0.1"
+        "abort-controller": "^3.0.0",
+        "data-uri-to-buffer": "^3.0.1",
+        "mrmime": "^1.0.0"
+      },
+      "dependencies": {
+        "@web-std/stream": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.3.tgz",
+          "integrity": "sha512-5MIngxWyq4rQiGoDAC2WhjLuDraW8+ff2LD2et4NRY933K3gL8CHlUXrh8ZZ3dC9A9Xaub8c9sl5exOJE58D9Q==",
+          "requires": {
+            "web-streams-polyfill": "^3.1.1"
+          }
+        }
       }
     },
     "@web-std/file": {
@@ -3308,9 +4017,9 @@
       }
     },
     "@web-std/form-data": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-3.0.2.tgz",
-      "integrity": "sha512-rhc8IRw66sJ0FHcnC84kT3mTN6eACTuNftkt1XSl1Ef6WRKq4Pz65xixxqZymAZl1K3USpwhLci4SKNn4PYxWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-3.1.0.tgz",
+      "integrity": "sha512-WkOrB8rnc2hEK2iVhDl9TFiPMptmxJA1HaIzSdc2/qk3XS4Ny4cCt6/V36U3XmoYKz0Md2YyK2uOZecoZWPAcA==",
       "requires": {
         "web-encoding": "1.1.5"
       }
@@ -3321,6 +4030,25 @@
       "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
       "requires": {
         "web-streams-polyfill": "^3.1.1"
+      }
+    },
+    "@web3-storage/car-block-validator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.0.tgz",
+      "integrity": "sha512-KKQ/M5WtpH/JlkX+bQYKzdG4azmSF495T7vpewje2xh7MBh1d94/BLblxCcLM/larWvXDxOkbAyTTdlECAAuUw==",
+      "requires": {
+        "@multiformats/blake2": "^1.0.13",
+        "@multiformats/murmur3": "^1.1.3",
+        "@multiformats/sha3": "^2.0.15",
+        "multiformats": "9.9.0",
+        "uint8arrays": "^3.1.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "@web3-storage/multipart-parser": {
@@ -3350,6 +4078,11 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       }
+    },
+    "actor": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/actor/-/actor-2.3.1.tgz",
+      "integrity": "sha512-ST/3wnvcP2tKDXnum7nLCLXm+/rsf8vPocXH2Fre6D8FQwNkGDd4JEitBlXj007VQJfiGYRQvXqwOBZVi+JtRg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -3420,6 +4153,11 @@
         }
       }
     },
+    "blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
     "blob-to-it": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
@@ -3444,20 +4182,20 @@
       }
     },
     "body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "requires": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
-        "raw-body": "2.5.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       }
@@ -3591,14 +4329,14 @@
       }
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
     },
     "cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -3698,9 +4436,9 @@
       }
     },
     "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3811,17 +4549,22 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
+    "eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
     "express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3837,7 +4580,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -3853,6 +4596,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
       "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+    },
+    "files-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.0.4.tgz",
+      "integrity": "sha512-sMNIVdpRh1uCSIaat3qnM3E6aA1C5FVn5/B16z8sN3gIMjZPkxtVCorkEL07xTcCIxVwTXzjU1Ota7Wif6RfQQ==",
+      "requires": {
+        "graceful-fs": "^4.2.10"
+      }
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -3939,6 +4690,11 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "hamt-sharding": {
       "version": "2.0.1",
@@ -4096,31 +4852,171 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "ipfs-car": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.7.0.tgz",
-      "integrity": "sha512-9ser6WWZ1ZMTCGbcVkRXUzOrpQ4SIiLfzIEnk+3LQsXbV09yeZg3ijhRuEXozEIYE68Go9JmOFshamsK9iKlNQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-1.2.0.tgz",
+      "integrity": "sha512-A++1UesxqwfNv14NmFxr4MHi+vD9rR6SWr87MU9o0315Mzqys48pEefL8rlCAA9cw2qKYeT/ZPYVtqIMAr6U1Q==",
       "requires": {
-        "@ipld/car": "^3.2.3",
-        "@web-std/blob": "^3.0.1",
-        "bl": "^5.0.0",
-        "blockstore-core": "^1.0.2",
-        "browser-readablestream-to-it": "^1.0.2",
-        "idb-keyval": "^6.0.3",
-        "interface-blockstore": "^2.0.2",
-        "ipfs-core-types": "^0.8.3",
-        "ipfs-core-utils": "^0.12.1",
-        "ipfs-unixfs-exporter": "^7.0.4",
-        "ipfs-unixfs-importer": "^9.0.4",
-        "ipfs-utils": "^9.0.2",
-        "it-all": "^1.0.5",
-        "it-last": "^1.0.5",
-        "it-pipe": "^1.1.0",
-        "meow": "^9.0.0",
-        "move-file": "^2.1.0",
-        "multiformats": "^9.6.3",
-        "stream-to-it": "^0.2.3",
-        "streaming-iterables": "^6.0.0",
-        "uint8arrays": "^3.0.0"
+        "@ipld/car": "^5.1.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.1",
+        "@ipld/dag-pb": "^4.0.2",
+        "@ipld/unixfs": "^3.0.0",
+        "@web3-storage/car-block-validator": "^1.0.1",
+        "files-from-path": "^1.0.0",
+        "ipfs-unixfs-exporter": "^13.0.1",
+        "multiformats": "^13.0.1",
+        "sade": "^1.8.1",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "@ipld/car": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.3.0.tgz",
+          "integrity": "sha512-OB8LVvJeVAFFGluNIkZeDZ/aGeoekFKsuIvNT9I5sJIb5WekQuW5+lekjQ7Z7mZ7DBKuke/kI4jBT1j0/akU1w==",
+          "requires": {
+            "@ipld/dag-cbor": "^9.0.7",
+            "cborg": "^4.0.5",
+            "multiformats": "^13.0.0",
+            "varint": "^6.0.0"
+          }
+        },
+        "@ipld/dag-cbor": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+          "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
+          "requires": {
+            "cborg": "^4.0.0",
+            "multiformats": "^13.1.0"
+          }
+        },
+        "@ipld/dag-pb": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
+          "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
+          "requires": {
+            "multiformats": "^13.1.0"
+          }
+        },
+        "@multiformats/murmur3": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
+          "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+          "requires": {
+            "multiformats": "^13.0.0",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "cborg": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+          "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA=="
+        },
+        "hamt-sharding": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.6.tgz",
+          "integrity": "sha512-nZeamxfymIWLpVcAN0CRrb7uVq3hCOGj9IcL6NMA6VVCVWqj+h9Jo/SmaWuS92AEDf1thmHsM5D5c70hM3j2Tg==",
+          "requires": {
+            "sparse-array": "^1.3.1",
+            "uint8arrays": "^5.0.1"
+          }
+        },
+        "interface-blockstore": {
+          "version": "5.2.10",
+          "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.10.tgz",
+          "integrity": "sha512-9K48hTvBCGsKVD3pF4ILgDcf+W2P/gq0oxLcsHGB6E6W6nDutYkzR+7k7bCs9REHrBEfKzcVDEKieiuNM9WRZg==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "multiformats": "^13.0.1"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
+          "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
+        },
+        "ipfs-unixfs": {
+          "version": "11.1.4",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.4.tgz",
+          "integrity": "sha512-RE4nyx5qgG2w7JOLj0Y0D7SfAR1ZkEdramNaBx0OSD4DlQ2Y2NORgc4FHfej3Pgy31v+QISDVP1pQJhdv3bUUg==",
+          "requires": {
+            "err-code": "^3.0.1",
+            "protons-runtime": "^5.4.0",
+            "uint8arraylist": "^2.4.8"
+          }
+        },
+        "ipfs-unixfs-exporter": {
+          "version": "13.5.0",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-13.5.0.tgz",
+          "integrity": "sha512-s1eWXzoyhQFNEAB1p+QE3adjhW+lBdgpORmmjiCLiruHs5z7T5zsAgRVcWpM8LWYhq2flRtJHObb7Hg73J+oLQ==",
+          "requires": {
+            "@ipld/dag-cbor": "^9.0.0",
+            "@ipld/dag-json": "^10.1.7",
+            "@ipld/dag-pb": "^4.0.0",
+            "@multiformats/murmur3": "^2.0.0",
+            "err-code": "^3.0.1",
+            "hamt-sharding": "^3.0.0",
+            "interface-blockstore": "^5.0.0",
+            "ipfs-unixfs": "^11.0.0",
+            "it-filter": "^3.0.2",
+            "it-last": "^3.0.2",
+            "it-map": "^3.0.3",
+            "it-parallel": "^3.0.0",
+            "it-pipe": "^3.0.1",
+            "it-pushable": "^3.1.0",
+            "multiformats": "^13.0.0",
+            "p-queue": "^8.0.1",
+            "progress-events": "^1.0.0"
+          }
+        },
+        "it-filter": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.4.tgz",
+          "integrity": "sha512-e0sz+st4sudK/zH6GZ/gRTRP8A/ADuJFCYDmRgMbZvR79y5+v4ZXav850bBZk5wL9zXaYZFxS1v/6Qi+Vjwh5g==",
+          "requires": {
+            "it-peekable": "^3.0.0"
+          }
+        },
+        "it-last": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.4.tgz",
+          "integrity": "sha512-Ns+KTsQWhs0KCvfv5X3Ck3lpoYxHcp4zUp4d+AOdmC8cXXqDuoZqAjfWhgCbxJubXyIYWdfE2nRcfWqgvZHP8Q=="
+        },
+        "it-map": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.5.tgz",
+          "integrity": "sha512-hB0TDXo/h4KSJJDSRLgAPmDroiXP6Fx1ck4Bzl3US9hHfZweTKsuiP0y4gXuTMcJlS6vj0bb+f70rhkD47ZA3w==",
+          "requires": {
+            "it-peekable": "^3.0.0"
+          }
+        },
+        "it-peekable": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.3.tgz",
+          "integrity": "sha512-Wx21JX/rMzTEl9flx3DGHuPV1KQFGOl8uoKfQtmZHgPQtGb89eQ6RyVd82h3HuP9Ghpt0WgBDlmmdWeHXqyx7w=="
+        },
+        "it-pipe": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+          "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+          "requires": {
+            "it-merge": "^3.0.0",
+            "it-pushable": "^3.1.2",
+            "it-stream-types": "^2.0.1"
+          }
+        },
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+        },
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
       }
     },
     "ipfs-core-types": {
@@ -4470,6 +5366,29 @@
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
       "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
     },
+    "it-merge": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.3.tgz",
+      "integrity": "sha512-FYVU15KC5pb/GQX1Ims+lee8d4pdqGVCpWr0lkNj8o4xuNo7jY71k6GuEiWdP+T7W1bJqewSxX5yoTy5yZpRVA==",
+      "requires": {
+        "it-pushable": "^3.2.0"
+      }
+    },
+    "it-parallel": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.6.tgz",
+      "integrity": "sha512-i7UM7I9LTkDJw3YIqXHFAPZX6CWYzGc+X3irdNrVExI4vPazrJdI7t5OqrSVN8CONXLAunCiqaSV/zZRbQR56A==",
+      "requires": {
+        "p-defer": "^4.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+          "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="
+        }
+      }
+    },
     "it-parallel-batch": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.10.tgz",
@@ -4487,6 +5406,26 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
       "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+    },
+    "it-pushable": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
+      "requires": {
+        "p-defer": "^4.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+          "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="
+        }
+      }
+    },
+    "it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
     },
     "it-take": {
       "version": "1.0.2",
@@ -4517,6 +5456,11 @@
           }
         }
       }
+    },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4675,6 +5619,16 @@
         "path-exists": "^4.0.0"
       }
     },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
+    },
+    "mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4726,9 +5680,9 @@
       "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
     },
     "nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ=="
     },
     "native-abort-controller": {
       "version": "1.0.4",
@@ -4748,14 +5702,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "nft.storage": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/nft.storage/-/nft.storage-6.4.1.tgz",
-      "integrity": "sha512-UwZ+QgDCr58X+vHN4BydqdB89M8Vaza+vkWR9RatC3rXuDfIyYE5T7oOV53tbiuhA8x5Yi56tlG3NI8wLfOO1A==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/nft.storage/-/nft.storage-7.1.1.tgz",
+      "integrity": "sha512-OHFeRiWLcGCWHX8Kx3yvSt7qGbHwEROl0kcN2xaHWBaR0ApYH5DnjlqczXSwP9WwBDtjhyDk4IHReXSwuZkB7Q==",
       "requires": {
         "@ipld/car": "^3.2.3",
         "@ipld/dag-cbor": "^6.0.13",
         "@web-std/blob": "^3.0.1",
-        "@web-std/fetch": "^3.0.3",
+        "@web-std/fetch": "^4.1.2",
         "@web-std/file": "^3.0.0",
         "@web-std/form-data": "^3.0.0",
         "carbites": "^1.0.6",
@@ -4876,6 +5830,15 @@
         "p-limit": "^2.2.0"
       }
     },
+    "p-queue": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
+      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "requires": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      }
+    },
     "p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -4884,6 +5847,11 @@
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
       }
+    },
+    "p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ=="
     },
     "p-try": {
       "version": "2.2.0",
@@ -4927,9 +5895,9 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true
     },
     "process-nextick-args": {
@@ -4937,10 +5905,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "progress-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
+      "integrity": "sha512-zIB6QDrSbPfRg+33FZalluFIowkbV5Xh1xSuetjG+rlC5he6u2dc6VQJ0TbMdlN3R1RHdpOqxEFMKTnQ+itUwA=="
+    },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -4957,6 +5930,31 @@
         "long": "^4.0.0"
       }
     },
+    "protons-runtime": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.4.0.tgz",
+      "integrity": "sha512-XfA++W/WlQOSyjUyuF5lgYBfXZUEMP01Oh1C2dSwZAlF2e/ZrMRPfWonXj6BGM+o8Xciv7w0tsRMKYwYEuQvaw==",
+      "requires": {
+        "uint8-varint": "^2.0.2",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+        },
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
+      }
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4967,9 +5965,9 @@
       }
     },
     "qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -4978,6 +5976,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
+    "rabin-rs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rabin-rs/-/rabin-rs-2.1.0.tgz",
+      "integrity": "sha512-5y72gAXPzIBsAMHcpxZP8eMDuDT98qMP1BqSDHRbHkJJXEgWIN1lA47LxUqzsK6jknOJtgfkQr9v+7qMlFDm6g=="
     },
     "rabin-wasm": {
       "version": "0.1.5",
@@ -5023,9 +6026,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -5069,9 +6072,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "type-fest": {
           "version": "0.6.0",
@@ -5172,6 +6175,14 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
+    "sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "requires": {
+        "mri": "^1.1.0"
+      }
+    },
     "safari-14-idb-fix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
@@ -5188,9 +6199,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -5403,10 +6414,57 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
+    "uint8-varint": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
+      "requires": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+        },
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
+      }
+    },
+    "uint8arraylist": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
+      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
+      "requires": {
+        "uint8arrays": "^5.0.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+        },
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
+      }
+    },
     "uint8arrays": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "requires": {
         "multiformats": "^9.4.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@ipld/car": "^5.3.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
-        "ipfs-car": "^1.2.0",
+        "kubo-rpc-client": "^4.1.1",
         "multer": "^1.4.5-lts.1",
         "nanoid": "^5.0.7",
-        "nft.storage": "^7.1.1"
+        "nft.storage": "^7.1.1",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -30,54 +32,86 @@
       "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@ipld/car": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.2.4.tgz",
-      "integrity": "sha512-rezKd+jk8AsTGOoJKqzfjLJ3WVft7NZNH95f0pfPbicROvzTyvHCNy567HzSUd6gRXZ9im29z5ZEv9Hw49jSYw==",
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.2.tgz",
+      "integrity": "sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA=="
+    },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
       "dependencies": {
-        "@ipld/dag-cbor": "^7.0.0",
-        "multiformats": "^9.5.4",
+        "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
+    "node_modules/@ipld/car": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.3.0.tgz",
+      "integrity": "sha512-OB8LVvJeVAFFGluNIkZeDZ/aGeoekFKsuIvNT9I5sJIb5WekQuW5+lekjQ7Z7mZ7DBKuke/kI4jBT1j0/akU1w==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.7",
+        "cborg": "^4.0.5",
+        "multiformats": "^13.0.0",
         "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ipld/car/node_modules/@ipld/dag-cbor": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.2.tgz",
-      "integrity": "sha512-V9EhJVWXqzjjRs0kiZfUXOaq8y6R2C4AAmfGoMeszqGOBgfACr5tFAgAwZY0e8z/OpmJWpCrZhzPRTZV0c/gjA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+      "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
       "dependencies": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/car/node_modules/cborg": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+      "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA==",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/@ipld/dag-cbor": {
@@ -88,6 +122,11 @@
         "cborg": "^1.5.4",
         "multiformats": "^9.5.4"
       }
+    },
+    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/@ipld/dag-json": {
       "version": "10.2.0",
@@ -110,11 +149,6 @@
         "cborg": "lib/bin.js"
       }
     },
-    "node_modules/@ipld/dag-json/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-    },
     "node_modules/@ipld/dag-pb": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.17.tgz",
@@ -123,85 +157,152 @@
         "multiformats": "^9.5.4"
       }
     },
-    "node_modules/@ipld/unixfs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-3.0.0.tgz",
-      "integrity": "sha512-Tj3/BPOlnemcZQ2ETIZAO8hqAs9KNzWyX5J9+JCL9jDwvYwjxeYjqJ3v+9DusNvTBmJhZnGVP6ijUHrsuOLp+g==",
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.2.0.tgz",
+      "integrity": "sha512-ImnGNl3El/AukgaojACT8i9SNW1FOsrThcQU/qA3w5tEBR5p84Uwgzl/nxa4X5vGinItUJ9jLEJmtkQJENoiGQ==",
       "dependencies": {
-        "@ipld/dag-pb": "^4.0.0",
-        "@multiformats/murmur3": "^2.1.3",
-        "@perma/map": "^1.0.2",
-        "actor": "^2.3.1",
-        "multiformats": "^13.0.1",
-        "protobufjs": "^7.1.2",
-        "rabin-rs": "^2.1.0"
+        "@multiformats/multiaddr": "^12.2.1",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
       }
     },
-    "node_modules/@ipld/unixfs/node_modules/@ipld/dag-pb": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
-      "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
+    "node_modules/@libp2p/logger": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.10.tgz",
+      "integrity": "sha512-JiRfJHO/D9Jlh2rJ6STnONoeQevBAdAZaGUxrtvBf4RFfucldSFEMOtdkFO8xFGuiA90Q2kj4BE2douG6fB3Lw==",
       "dependencies": {
+        "@libp2p/interface": "^1.2.0",
+        "@multiformats/multiaddr": "^12.2.1",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.11",
         "multiformats": "^13.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
-    "node_modules/@ipld/unixfs/node_modules/@multiformats/murmur3": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
-      "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+    "node_modules/@libp2p/logger/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "8.2.11",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.11.tgz",
+      "integrity": "sha512-9E0iXehfp/j0UbZ2mvlYB4K9pP7uQBCppfuy8WHs1EHF6wLQrM9+zwyX+8Qt6HnH4GKZRyXX/CNXm6oD4+QYgA==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
+      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
+    },
+    "node_modules/@libp2p/logger/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@libp2p/logger/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.0.10.tgz",
+      "integrity": "sha512-cR5dQ5fPcxP4LLSXDgo+TSOhtElZSwRXVSSgT/GM/Vvbua5M91NzsksYfd/lg8XwTCSvTER0qmE6ZIR05vjQrA==",
+      "dependencies": {
+        "@libp2p/interface": "^1.2.0",
+        "multiformats": "^13.1.0",
+        "uint8arrays": "^5.0.3"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.6.tgz",
+      "integrity": "sha512-nt/5UqjMPtyvkG9BQYdJ4GfLK3nMqGpFZOzf4hAmIa0sJh2LlS9YKXZ4FgwBDsaHvzZqR/rUFIywIc7pkHNNuw==",
+      "dependencies": {
+        "@types/dns-packet": "^5.6.5",
+        "buffer": "^6.0.3",
+        "dns-packet": "^5.6.1",
+        "hashlru": "^2.3.0",
+        "p-queue": "^8.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.2.1.tgz",
+      "integrity": "sha512-UwjoArBbv64FlaetV4DDwh+PUMfzXUBltxQwdh+uTYnGFzVa8ZfJsn1vt1RJlJ6+Xtrm3RMekF/B+K338i2L5Q==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^1.0.0",
+        "@multiformats/dns": "^1.0.3",
         "multiformats": "^13.0.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
       }
     },
-    "node_modules/@ipld/unixfs/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@ipld/unixfs/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-    },
-    "node_modules/@ipld/unixfs/node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
-      "hasInstallScript": true,
+    "node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-10.0.1.tgz",
+      "integrity": "sha512-RtOBRJucMCzINPytvt1y7tJ2jr4aSKJmv3DF7/C515RJO9+nu9sZHdsk9vn251OtN8k21rAGlIHESt/BSJWAnQ==",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
       }
     },
-    "node_modules/@multiformats/blake2": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
-      "integrity": "sha512-T1Kzya0wjj85CaVeRSpJ858EnSvW1pw94GSitxYf84VsNdv5XYbJ6QG8y26Ft1bVALzrUCmqkQrR53QHSyu6RA==",
+    "node_modules/@multiformats/multiaddr/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
       "dependencies": {
-        "blakejs": "^1.1.1",
-        "multiformats": "^9.5.4"
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@multiformats/murmur3": {
@@ -213,41 +314,10 @@
         "murmurhash3js-revisited": "^3.0.0"
       }
     },
-    "node_modules/@multiformats/sha3": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.17.tgz",
-      "integrity": "sha512-7ik6pk178qLO2cpNucgf48UnAOBMkq/2H92DP4SprZOJqM9zqbVaKS7XyYW6UvhRsDJ3wi921fYv1ihTtQHLtA==",
-      "dependencies": {
-        "js-sha3": "^0.8.0",
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@perma/map": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@perma/map/-/map-1.0.3.tgz",
-      "integrity": "sha512-Bf5njk0fnJGTFE2ETntq0N1oJ6YdCPIpTDn3R3KYZJQdeYSOCNL7mBrFlGnbqav8YQhJA/p81pvHINX9vAtHkQ==",
-      "dependencies": {
-        "@multiformats/murmur3": "^2.1.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      }
-    },
-    "node_modules/@perma/map/node_modules/@multiformats/murmur3": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
-      "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
-      "dependencies": {
-        "multiformats": "^13.0.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@perma/map/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -302,6 +372,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -392,23 +470,6 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
-    "node_modules/@web3-storage/car-block-validator": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.0.tgz",
-      "integrity": "sha512-KKQ/M5WtpH/JlkX+bQYKzdG4azmSF495T7vpewje2xh7MBh1d94/BLblxCcLM/larWvXDxOkbAyTTdlECAAuUw==",
-      "dependencies": {
-        "@multiformats/blake2": "^1.0.13",
-        "@multiformats/murmur3": "^1.1.3",
-        "@multiformats/sha3": "^2.0.15",
-        "multiformats": "9.9.0",
-        "uint8arrays": "^3.1.1"
-      }
-    },
-    "node_modules/@web3-storage/car-block-validator/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
@@ -442,11 +503,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/actor": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/actor/-/actor-2.3.1.tgz",
-      "integrity": "sha512-ST/3wnvcP2tKDXnum7nLCLXm+/rsf8vPocXH2Fre6D8FQwNkGDd4JEitBlXj007VQJfiGYRQvXqwOBZVi+JtRg=="
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -544,11 +600,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
-    },
     "node_modules/blob-to-it": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
@@ -571,6 +622,11 @@
         "it-take": "^1.0.1",
         "multiformats": "^9.4.7"
       }
+    },
+    "node_modules/blockstore-core/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -703,6 +759,30 @@
         "multiformats": "^9.0.4"
       }
     },
+    "node_modules/carbites/node_modules/@ipld/car": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.2.4.tgz",
+      "integrity": "sha512-rezKd+jk8AsTGOoJKqzfjLJ3WVft7NZNH95f0pfPbicROvzTyvHCNy567HzSUd6gRXZ9im29z5ZEv9Hw49jSYw==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "multiformats": "^9.5.4",
+        "varint": "^6.0.0"
+      }
+    },
+    "node_modules/carbites/node_modules/@ipld/car/node_modules/@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/carbites/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/cborg": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.4.tgz",
@@ -803,6 +883,36 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/dag-jose": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-5.0.0.tgz",
+      "integrity": "sha512-9IVE/OyubkGEGEuqRhSxpugwBtVKn6gd2fw2AMmlpYowjUrFfDpLPT0QToBstfyFgI9XNsKIQxQRM8Dq+nMASQ==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "multiformats": "^13.1.0"
+      }
+    },
+    "node_modules/dag-jose/node_modules/@ipld/dag-cbor": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+      "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/dag-jose/node_modules/cborg": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+      "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA==",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -912,6 +1022,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -929,9 +1050,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-fetch": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
-      "integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
+      "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
       "dependencies": {
         "encoding": "^0.1.13"
       },
@@ -1111,17 +1232,6 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
       "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
     },
-    "node_modules/files-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.0.4.tgz",
-      "integrity": "sha512-sMNIVdpRh1uCSIaat3qnM3E6aA1C5FVn5/B16z8sN3gIMjZPkxtVCorkEL07xTcCIxVwTXzjU1Ota7Wif6RfQQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.10"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -1238,11 +1348,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
     "node_modules/hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -1326,6 +1431,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
@@ -1413,6 +1523,11 @@
         "multiformats": "^9.0.4"
       }
     },
+    "node_modules/interface-blockstore/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/interface-datastore": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
@@ -1468,202 +1583,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/ipfs-car": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-1.2.0.tgz",
-      "integrity": "sha512-A++1UesxqwfNv14NmFxr4MHi+vD9rR6SWr87MU9o0315Mzqys48pEefL8rlCAA9cw2qKYeT/ZPYVtqIMAr6U1Q==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-json": "^10.0.1",
-        "@ipld/dag-pb": "^4.0.2",
-        "@ipld/unixfs": "^3.0.0",
-        "@web3-storage/car-block-validator": "^1.0.1",
-        "files-from-path": "^1.0.0",
-        "ipfs-unixfs-exporter": "^13.0.1",
-        "multiformats": "^13.0.1",
-        "sade": "^1.8.1",
-        "varint": "^6.0.0"
-      },
-      "bin": {
-        "🚘": "bin.js",
-        "ipfs-car": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/@ipld/car": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.3.0.tgz",
-      "integrity": "sha512-OB8LVvJeVAFFGluNIkZeDZ/aGeoekFKsuIvNT9I5sJIb5WekQuW5+lekjQ7Z7mZ7DBKuke/kI4jBT1j0/akU1w==",
-      "dependencies": {
-        "@ipld/dag-cbor": "^9.0.7",
-        "cborg": "^4.0.5",
-        "multiformats": "^13.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/@ipld/dag-cbor": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
-      "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
-      "dependencies": {
-        "cborg": "^4.0.0",
-        "multiformats": "^13.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/@ipld/dag-pb": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
-      "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
-      "dependencies": {
-        "multiformats": "^13.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/@multiformats/murmur3": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
-      "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
-      "dependencies": {
-        "multiformats": "^13.0.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/cborg": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
-      "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA==",
-      "bin": {
-        "cborg": "lib/bin.js"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/hamt-sharding": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.6.tgz",
-      "integrity": "sha512-nZeamxfymIWLpVcAN0CRrb7uVq3hCOGj9IcL6NMA6VVCVWqj+h9Jo/SmaWuS92AEDf1thmHsM5D5c70hM3j2Tg==",
-      "dependencies": {
-        "sparse-array": "^1.3.1",
-        "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/interface-blockstore": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.10.tgz",
-      "integrity": "sha512-9K48hTvBCGsKVD3pF4ILgDcf+W2P/gq0oxLcsHGB6E6W6nDutYkzR+7k7bCs9REHrBEfKzcVDEKieiuNM9WRZg==",
-      "dependencies": {
-        "interface-store": "^5.0.0",
-        "multiformats": "^13.0.1"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/interface-store": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
-      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
-    },
-    "node_modules/ipfs-car/node_modules/ipfs-unixfs": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.4.tgz",
-      "integrity": "sha512-RE4nyx5qgG2w7JOLj0Y0D7SfAR1ZkEdramNaBx0OSD4DlQ2Y2NORgc4FHfej3Pgy31v+QISDVP1pQJhdv3bUUg==",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/ipfs-unixfs-exporter": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-13.5.0.tgz",
-      "integrity": "sha512-s1eWXzoyhQFNEAB1p+QE3adjhW+lBdgpORmmjiCLiruHs5z7T5zsAgRVcWpM8LWYhq2flRtJHObb7Hg73J+oLQ==",
-      "dependencies": {
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-json": "^10.1.7",
-        "@ipld/dag-pb": "^4.0.0",
-        "@multiformats/murmur3": "^2.0.0",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^3.0.0",
-        "interface-blockstore": "^5.0.0",
-        "ipfs-unixfs": "^11.0.0",
-        "it-filter": "^3.0.2",
-        "it-last": "^3.0.2",
-        "it-map": "^3.0.3",
-        "it-parallel": "^3.0.0",
-        "it-pipe": "^3.0.1",
-        "it-pushable": "^3.1.0",
-        "multiformats": "^13.0.0",
-        "p-queue": "^8.0.1",
-        "progress-events": "^1.0.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/it-filter": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.4.tgz",
-      "integrity": "sha512-e0sz+st4sudK/zH6GZ/gRTRP8A/ADuJFCYDmRgMbZvR79y5+v4ZXav850bBZk5wL9zXaYZFxS1v/6Qi+Vjwh5g==",
-      "dependencies": {
-        "it-peekable": "^3.0.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/it-last": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.4.tgz",
-      "integrity": "sha512-Ns+KTsQWhs0KCvfv5X3Ck3lpoYxHcp4zUp4d+AOdmC8cXXqDuoZqAjfWhgCbxJubXyIYWdfE2nRcfWqgvZHP8Q=="
-    },
-    "node_modules/ipfs-car/node_modules/it-map": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.5.tgz",
-      "integrity": "sha512-hB0TDXo/h4KSJJDSRLgAPmDroiXP6Fx1ck4Bzl3US9hHfZweTKsuiP0y4gXuTMcJlS6vj0bb+f70rhkD47ZA3w==",
-      "dependencies": {
-        "it-peekable": "^3.0.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/it-peekable": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.3.tgz",
-      "integrity": "sha512-Wx21JX/rMzTEl9flx3DGHuPV1KQFGOl8uoKfQtmZHgPQtGb89eQ6RyVd82h3HuP9Ghpt0WgBDlmmdWeHXqyx7w=="
-    },
-    "node_modules/ipfs-car/node_modules/it-pipe": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
-      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
-      "dependencies": {
-        "it-merge": "^3.0.0",
-        "it-pushable": "^3.1.2",
-        "it-stream-types": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-    },
-    "node_modules/ipfs-car/node_modules/uint8arrays": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
-      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
     "node_modules/ipfs-core-types": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.8.4.tgz",
@@ -1673,6 +1592,11 @@
         "multiaddr": "^10.0.0",
         "multiformats": "^9.4.13"
       }
+    },
+    "node_modules/ipfs-core-types/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/ipfs-core-utils": {
       "version": "0.12.2",
@@ -1721,6 +1645,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/ipfs-core-utils/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/ipfs-core-utils/node_modules/nanoid": {
       "version": "3.3.4",
@@ -1776,6 +1705,11 @@
         "multiformats": "^9.5.4"
       }
     },
+    "node_modules/ipfs-unixfs-exporter/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/ipfs-unixfs-importer": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.10.tgz",
@@ -1801,6 +1735,11 @@
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/ipfs-unixfs-importer/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/ipfs-utils": {
       "version": "9.0.7",
@@ -2124,22 +2063,6 @@
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
       "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
     },
-    "node_modules/it-merge": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.3.tgz",
-      "integrity": "sha512-FYVU15KC5pb/GQX1Ims+lee8d4pdqGVCpWr0lkNj8o4xuNo7jY71k6GuEiWdP+T7W1bJqewSxX5yoTy5yZpRVA==",
-      "dependencies": {
-        "it-pushable": "^3.2.0"
-      }
-    },
-    "node_modules/it-parallel": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.6.tgz",
-      "integrity": "sha512-i7UM7I9LTkDJw3YIqXHFAPZX6CWYzGc+X3irdNrVExI4vPazrJdI7t5OqrSVN8CONXLAunCiqaSV/zZRbQR56A==",
-      "dependencies": {
-        "p-defer": "^4.0.0"
-      }
-    },
     "node_modules/it-parallel-batch": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.10.tgz",
@@ -2148,26 +2071,10 @@
         "it-batch": "^1.0.9"
       }
     },
-    "node_modules/it-parallel/node_modules/p-defer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
-      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/it-peekable": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
       "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
-    },
-    "node_modules/it-pipe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
-      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
     },
     "node_modules/it-pushable": {
       "version": "3.2.3",
@@ -2228,11 +2135,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2249,6 +2151,200 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kubo-rpc-client": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-4.1.1.tgz",
+      "integrity": "sha512-vxIkTQLvDqd2DEcBfz7DWegAidYtopmWUR/UhWyuuss9+JNFzV5neBn8BKxSDHoLJPvkxJpqXDaJhsb7ZuPouQ==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface": "^1.2.0",
+        "@libp2p/logger": "^4.0.10",
+        "@libp2p/peer-id": "^4.0.10",
+        "@multiformats/multiaddr": "^12.2.1",
+        "@multiformats/multiaddr-to-uri": "^10.0.1",
+        "any-signal": "^4.1.1",
+        "blob-to-it": "^2.0.5",
+        "browser-readablestream-to-it": "^2.0.5",
+        "dag-jose": "^5.0.0",
+        "electron-fetch": "^1.9.1",
+        "err-code": "^3.0.1",
+        "ipfs-unixfs": "^11.1.4",
+        "iso-url": "^1.2.1",
+        "it-all": "^3.0.4",
+        "it-first": "^3.0.4",
+        "it-glob": "^2.0.6",
+        "it-last": "^3.0.4",
+        "it-map": "^3.0.5",
+        "it-peekable": "^3.0.3",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "nanoid": "^5.0.7",
+        "native-fetch": "^4.0.2",
+        "parse-duration": "^1.0.2",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^1.0.1",
+        "uint8arrays": "^5.0.3",
+        "wherearewe": "^2.0.1"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@ipld/dag-cbor": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+      "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@ipld/dag-pb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
+      "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
+      "dependencies": {
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/blob-to-it": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-2.0.5.tgz",
+      "integrity": "sha512-3VIFla8L4JuB+0WCdf+0POI7E1tTl8mhdGiwwwmnZEu6QjRJciS9fIvz8NgWY9URb0iagXYModGEYTcYeq9BMg==",
+      "dependencies": {
+        "browser-readablestream-to-it": "^2.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/browser-readablestream-to-it": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.5.tgz",
+      "integrity": "sha512-obLCT9jnxAeZlbaRWluUiZrcSJEoi2JkM0eoiJqlIP7MFwZwZjcB6giZvD343PXfr96ilD91M/wFqFvyAZq+Gg=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/cborg": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+      "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/ipfs-unixfs": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.4.tgz",
+      "integrity": "sha512-RE4nyx5qgG2w7JOLj0Y0D7SfAR1ZkEdramNaBx0OSD4DlQ2Y2NORgc4FHfej3Pgy31v+QISDVP1pQJhdv3bUUg==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-all": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.4.tgz",
+      "integrity": "sha512-UMiy0i9DqCHBdWvMbzdYvVGa5/w4t1cc4nchpbnjdLhklglv8mQeEYnii0gvKESJuL1zV32Cqdb33R6/GPfxpQ=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-first": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.4.tgz",
+      "integrity": "sha512-FtQl84iTNxN5EItP/JgL28V2rzNMkCzTUlNoj41eVdfix2z1DBuLnBqZ0hzYhGGa1rMpbQf0M7CQSA2adlrLJg=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-glob": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-2.0.6.tgz",
+      "integrity": "sha512-4C6ccz4nhqrq7yZMzBr3MsKhyL+rlnLXIPceyGG6ogl3Lx3eeWMv1RtlySJwFi6q+jVcPyTpeYt/xftwI2JEQQ==",
+      "dependencies": {
+        "minimatch": "^9.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-last": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.4.tgz",
+      "integrity": "sha512-Ns+KTsQWhs0KCvfv5X3Ck3lpoYxHcp4zUp4d+AOdmC8cXXqDuoZqAjfWhgCbxJubXyIYWdfE2nRcfWqgvZHP8Q=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-map": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.5.tgz",
+      "integrity": "sha512-hB0TDXo/h4KSJJDSRLgAPmDroiXP6Fx1ck4Bzl3US9hHfZweTKsuiP0y4gXuTMcJlS6vj0bb+f70rhkD47ZA3w==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-peekable": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.3.tgz",
+      "integrity": "sha512-Wx21JX/rMzTEl9flx3DGHuPV1KQFGOl8uoKfQtmZHgPQtGb89eQ6RyVd82h3HuP9Ghpt0WgBDlmmdWeHXqyx7w=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/native-fetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
+      "peerDependencies": {
+        "undici": "*"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/react-native-fetch-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "dependencies": {
+        "p-defer": "^3.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/stream-to-it": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-1.0.1.tgz",
+      "integrity": "sha512-AqHYAYPHcmvMrcLNgncE/q0Aj/ajP6A4qGhxP6EVn7K3YTNs0bJpJyk57wc2Heb7MUL64jurvmnmui8D9kjZgA==",
+      "dependencies": {
+        "it-stream-types": "^2.0.1"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -2451,14 +2547,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -2510,10 +2598,15 @@
         "multiaddr": "^10.0.0"
       }
     },
+    "node_modules/multiaddr/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/multiformats": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.7.0.tgz",
-      "integrity": "sha512-uv/tcgwk0yN4DStopnBN4GTgvaAlYdy6KnZpuzEPFOYQd71DYFJjs0MN1ERElAflrZaYyGBWXyGxL5GgrxIx0Q=="
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -2584,6 +2677,25 @@
         "throttled-queue": "^2.1.2"
       }
     },
+    "node_modules/nft.storage/node_modules/@ipld/car": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.2.4.tgz",
+      "integrity": "sha512-rezKd+jk8AsTGOoJKqzfjLJ3WVft7NZNH95f0pfPbicROvzTyvHCNy567HzSUd6gRXZ9im29z5ZEv9Hw49jSYw==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "multiformats": "^9.5.4",
+        "varint": "^6.0.0"
+      }
+    },
+    "node_modules/nft.storage/node_modules/@ipld/car/node_modules/@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
     "node_modules/nft.storage/node_modules/ipfs-car": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.2.tgz",
@@ -2615,6 +2727,16 @@
         "🚘": "dist/cjs/cli/cli.js",
         "ipfs-car": "dist/cjs/cli/cli.js"
       }
+    },
+    "node_modules/nft.storage/node_modules/it-pipe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
+      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+    },
+    "node_modules/nft.storage/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/node-fetch": {
       "name": "@achingbrain/node-fetch",
@@ -2828,6 +2950,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "node_modules/prettier": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
@@ -2892,11 +3019,6 @@
         "uint8arrays": "^5.0.1"
       }
     },
-    "node_modules/protons-runtime/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-    },
     "node_modules/protons-runtime/node_modules/uint8arrays": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
@@ -2938,11 +3060,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/rabin-rs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rabin-rs/-/rabin-rs-2.1.0.tgz",
-      "integrity": "sha512-5y72gAXPzIBsAMHcpxZP8eMDuDT98qMP1BqSDHRbHkJJXEgWIN1lA47LxUqzsK6jknOJtgfkQr9v+7qMlFDm6g=="
     },
     "node_modules/rabin-wasm": {
       "version": "0.1.5",
@@ -3181,17 +3298,6 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/sade": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "dependencies": {
-        "mri": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/safari-14-idb-fix": {
@@ -3501,11 +3607,6 @@
         "uint8arrays": "^5.0.0"
       }
     },
-    "node_modules/uint8-varint/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-    },
     "node_modules/uint8-varint/node_modules/uint8arrays": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
@@ -3521,11 +3622,6 @@
       "dependencies": {
         "uint8arrays": "^5.0.1"
       }
-    },
-    "node_modules/uint8arraylist/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
     },
     "node_modules/uint8arraylist/node_modules/uint8arrays": {
       "version": "5.0.3",
@@ -3543,6 +3639,11 @@
         "multiformats": "^9.4.2"
       }
     },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -3555,6 +3656,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.14.1.tgz",
+      "integrity": "sha512-mAel3i4BsYhkeVPXeIPXVGPJKeBzqCieZYoFsbWfUzd68JmHByhc1Plit5WlylxXFaGpgkZB8mExlxnt+Q1p7A==",
+      "peer": true,
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/unpipe": {
@@ -3589,6 +3699,18 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -3630,6 +3752,18 @@
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "dependencies": {
+        "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/which-boxed-primitive": {
@@ -3695,46 +3829,67 @@
       "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
     },
     "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "requires": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "@chainsafe/is-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.2.tgz",
+      "integrity": "sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA=="
+    },
+    "@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "requires": {
+        "@chainsafe/is-ip": "^2.0.1"
       }
     },
     "@ipld/car": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.2.4.tgz",
-      "integrity": "sha512-rezKd+jk8AsTGOoJKqzfjLJ3WVft7NZNH95f0pfPbicROvzTyvHCNy567HzSUd6gRXZ9im29z5ZEv9Hw49jSYw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.3.0.tgz",
+      "integrity": "sha512-OB8LVvJeVAFFGluNIkZeDZ/aGeoekFKsuIvNT9I5sJIb5WekQuW5+lekjQ7Z7mZ7DBKuke/kI4jBT1j0/akU1w==",
       "requires": {
-        "@ipld/dag-cbor": "^7.0.0",
-        "multiformats": "^9.5.4",
+        "@ipld/dag-cbor": "^9.0.7",
+        "cborg": "^4.0.5",
+        "multiformats": "^13.0.0",
         "varint": "^6.0.0"
       },
       "dependencies": {
         "@ipld/dag-cbor": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.2.tgz",
-          "integrity": "sha512-V9EhJVWXqzjjRs0kiZfUXOaq8y6R2C4AAmfGoMeszqGOBgfACr5tFAgAwZY0e8z/OpmJWpCrZhzPRTZV0c/gjA==",
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+          "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
           "requires": {
-            "cborg": "^1.6.0",
-            "multiformats": "^9.5.4"
+            "cborg": "^4.0.0",
+            "multiformats": "^13.1.0"
           }
+        },
+        "cborg": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+          "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA=="
         }
       }
     },
@@ -3745,6 +3900,13 @@
       "requires": {
         "cborg": "^1.5.4",
         "multiformats": "^9.5.4"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "@ipld/dag-json": {
@@ -3760,11 +3922,6 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
           "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA=="
-        },
-        "multiformats": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
         }
       }
     },
@@ -3774,77 +3931,156 @@
       "integrity": "sha512-AmzOdmdv5hT8iGsrbpzm5R0Fvk7DEbtwcglG2gJLvW9q3zwb+E681hY4EwEELypM1Rfnp/JDA9dGqYcpEi/iAg==",
       "requires": {
         "multiformats": "^9.5.4"
-      }
-    },
-    "@ipld/unixfs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-3.0.0.tgz",
-      "integrity": "sha512-Tj3/BPOlnemcZQ2ETIZAO8hqAs9KNzWyX5J9+JCL9jDwvYwjxeYjqJ3v+9DusNvTBmJhZnGVP6ijUHrsuOLp+g==",
-      "requires": {
-        "@ipld/dag-pb": "^4.0.0",
-        "@multiformats/murmur3": "^2.1.3",
-        "@perma/map": "^1.0.2",
-        "actor": "^2.3.1",
-        "multiformats": "^13.0.1",
-        "protobufjs": "^7.1.2",
-        "rabin-rs": "^2.1.0"
       },
       "dependencies": {
-        "@ipld/dag-pb": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
-          "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
-          "requires": {
-            "multiformats": "^13.1.0"
-          }
-        },
-        "@multiformats/murmur3": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
-          "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
-          "requires": {
-            "multiformats": "^13.0.0",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        },
-        "long": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-        },
         "multiformats": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-        },
-        "protobufjs": {
-          "version": "7.2.6",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-          "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
+      }
+    },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "@libp2p/interface": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.2.0.tgz",
+      "integrity": "sha512-ImnGNl3El/AukgaojACT8i9SNW1FOsrThcQU/qA3w5tEBR5p84Uwgzl/nxa4X5vGinItUJ9jLEJmtkQJENoiGQ==",
+      "requires": {
+        "@multiformats/multiaddr": "^12.2.1",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "@libp2p/logger": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.10.tgz",
+      "integrity": "sha512-JiRfJHO/D9Jlh2rJ6STnONoeQevBAdAZaGUxrtvBf4RFfucldSFEMOtdkFO8xFGuiA90Q2kj4BE2douG6fB3Lw==",
+      "requires": {
+        "@libp2p/interface": "^1.2.0",
+        "@multiformats/multiaddr": "^12.2.1",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.11",
+        "multiformats": "^13.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
+            "ms": "2.1.2"
+          }
+        },
+        "interface-datastore": {
+          "version": "8.2.11",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.11.tgz",
+          "integrity": "sha512-9E0iXehfp/j0UbZ2mvlYB4K9pP7uQBCppfuy8WHs1EHF6wLQrM9+zwyX+8Qt6HnH4GKZRyXX/CNXm6oD4+QYgA==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "uint8arrays": "^5.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
+          "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
           }
         }
       }
     },
-    "@multiformats/blake2": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
-      "integrity": "sha512-T1Kzya0wjj85CaVeRSpJ858EnSvW1pw94GSitxYf84VsNdv5XYbJ6QG8y26Ft1bVALzrUCmqkQrR53QHSyu6RA==",
+    "@libp2p/peer-id": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.0.10.tgz",
+      "integrity": "sha512-cR5dQ5fPcxP4LLSXDgo+TSOhtElZSwRXVSSgT/GM/Vvbua5M91NzsksYfd/lg8XwTCSvTER0qmE6ZIR05vjQrA==",
       "requires": {
-        "blakejs": "^1.1.1",
-        "multiformats": "^9.5.4"
+        "@libp2p/interface": "^1.2.0",
+        "multiformats": "^13.1.0",
+        "uint8arrays": "^5.0.3"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
+      }
+    },
+    "@multiformats/dns": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.6.tgz",
+      "integrity": "sha512-nt/5UqjMPtyvkG9BQYdJ4GfLK3nMqGpFZOzf4hAmIa0sJh2LlS9YKXZ4FgwBDsaHvzZqR/rUFIywIc7pkHNNuw==",
+      "requires": {
+        "@types/dns-packet": "^5.6.5",
+        "buffer": "^6.0.3",
+        "dns-packet": "^5.6.1",
+        "hashlru": "^2.3.0",
+        "p-queue": "^8.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
+      }
+    },
+    "@multiformats/multiaddr": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.2.1.tgz",
+      "integrity": "sha512-UwjoArBbv64FlaetV4DDwh+PUMfzXUBltxQwdh+uTYnGFzVa8ZfJsn1vt1RJlJ6+Xtrm3RMekF/B+K338i2L5Q==",
+      "requires": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^1.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
+      }
+    },
+    "@multiformats/multiaddr-to-uri": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-10.0.1.tgz",
+      "integrity": "sha512-RtOBRJucMCzINPytvt1y7tJ2jr4aSKJmv3DF7/C515RJO9+nu9sZHdsk9vn251OtN8k21rAGlIHESt/BSJWAnQ==",
+      "requires": {
+        "@multiformats/multiaddr": "^12.0.0"
       }
     },
     "@multiformats/murmur3": {
@@ -3854,39 +4090,12 @@
       "requires": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
-      }
-    },
-    "@multiformats/sha3": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.17.tgz",
-      "integrity": "sha512-7ik6pk178qLO2cpNucgf48UnAOBMkq/2H92DP4SprZOJqM9zqbVaKS7XyYW6UvhRsDJ3wi921fYv1ihTtQHLtA==",
-      "requires": {
-        "js-sha3": "^0.8.0",
-        "multiformats": "^9.5.4"
-      }
-    },
-    "@perma/map": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@perma/map/-/map-1.0.3.tgz",
-      "integrity": "sha512-Bf5njk0fnJGTFE2ETntq0N1oJ6YdCPIpTDn3R3KYZJQdeYSOCNL7mBrFlGnbqav8YQhJA/p81pvHINX9vAtHkQ==",
-      "requires": {
-        "@multiformats/murmur3": "^2.1.0",
-        "murmurhash3js-revisited": "^3.0.0"
       },
       "dependencies": {
-        "@multiformats/murmur3": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
-          "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
-          "requires": {
-            "multiformats": "^13.0.0",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        },
         "multiformats": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
         }
       }
     },
@@ -3943,6 +4152,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/long": {
       "version": "4.0.2",
@@ -4032,25 +4249,6 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
-    "@web3-storage/car-block-validator": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.0.tgz",
-      "integrity": "sha512-KKQ/M5WtpH/JlkX+bQYKzdG4azmSF495T7vpewje2xh7MBh1d94/BLblxCcLM/larWvXDxOkbAyTTdlECAAuUw==",
-      "requires": {
-        "@multiformats/blake2": "^1.0.13",
-        "@multiformats/murmur3": "^1.1.3",
-        "@multiformats/sha3": "^2.0.15",
-        "multiformats": "9.9.0",
-        "uint8arrays": "^3.1.1"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        }
-      }
-    },
     "@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
@@ -4078,11 +4276,6 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       }
-    },
-    "actor": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/actor/-/actor-2.3.1.tgz",
-      "integrity": "sha512-ST/3wnvcP2tKDXnum7nLCLXm+/rsf8vPocXH2Fre6D8FQwNkGDd4JEitBlXj007VQJfiGYRQvXqwOBZVi+JtRg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -4153,11 +4346,6 @@
         }
       }
     },
-    "blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
-    },
     "blob-to-it": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
@@ -4179,6 +4367,13 @@
         "it-filter": "^1.0.2",
         "it-take": "^1.0.1",
         "multiformats": "^9.4.7"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "body-parser": {
@@ -4274,6 +4469,34 @@
         "@ipld/dag-cbor": "^6.0.3",
         "@ipld/dag-pb": "^2.0.2",
         "multiformats": "^9.0.4"
+      },
+      "dependencies": {
+        "@ipld/car": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.2.4.tgz",
+          "integrity": "sha512-rezKd+jk8AsTGOoJKqzfjLJ3WVft7NZNH95f0pfPbicROvzTyvHCNy567HzSUd6gRXZ9im29z5ZEv9Hw49jSYw==",
+          "requires": {
+            "@ipld/dag-cbor": "^7.0.0",
+            "multiformats": "^9.5.4",
+            "varint": "^6.0.0"
+          },
+          "dependencies": {
+            "@ipld/dag-cbor": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+              "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+              "requires": {
+                "cborg": "^1.6.0",
+                "multiformats": "^9.5.4"
+              }
+            }
+          }
+        },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "cborg": {
@@ -4357,6 +4580,31 @@
         "vary": "^1"
       }
     },
+    "dag-jose": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-5.0.0.tgz",
+      "integrity": "sha512-9IVE/OyubkGEGEuqRhSxpugwBtVKn6gd2fw2AMmlpYowjUrFfDpLPT0QToBstfyFgI9XNsKIQxQRM8Dq+nMASQ==",
+      "requires": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "dependencies": {
+        "@ipld/dag-cbor": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+          "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
+          "requires": {
+            "cborg": "^4.0.0",
+            "multiformats": "^13.1.0"
+          }
+        },
+        "cborg": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+          "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA=="
+        }
+      }
+    },
     "data-uri-to-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
@@ -4435,6 +4683,14 @@
         }
       }
     },
+    "dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "requires": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      }
+    },
     "dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -4446,9 +4702,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-fetch": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
-      "integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
+      "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
       "requires": {
         "encoding": "^0.1.13"
       }
@@ -4597,14 +4853,6 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
       "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
     },
-    "files-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.0.4.tgz",
-      "integrity": "sha512-sMNIVdpRh1uCSIaat3qnM3E6aA1C5FVn5/B16z8sN3gIMjZPkxtVCorkEL07xTcCIxVwTXzjU1Ota7Wif6RfQQ==",
-      "requires": {
-        "graceful-fs": "^4.2.10"
-      }
-    },
     "finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -4691,11 +4939,6 @@
         "get-intrinsic": "^1.1.1"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
     "hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -4748,6 +4991,11 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "hosted-git-info": {
       "version": "4.1.0",
@@ -4807,6 +5055,13 @@
       "requires": {
         "interface-store": "^2.0.2",
         "multiformats": "^9.0.4"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "interface-datastore": {
@@ -4851,174 +5106,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
-    "ipfs-car": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-1.2.0.tgz",
-      "integrity": "sha512-A++1UesxqwfNv14NmFxr4MHi+vD9rR6SWr87MU9o0315Mzqys48pEefL8rlCAA9cw2qKYeT/ZPYVtqIMAr6U1Q==",
-      "requires": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-json": "^10.0.1",
-        "@ipld/dag-pb": "^4.0.2",
-        "@ipld/unixfs": "^3.0.0",
-        "@web3-storage/car-block-validator": "^1.0.1",
-        "files-from-path": "^1.0.0",
-        "ipfs-unixfs-exporter": "^13.0.1",
-        "multiformats": "^13.0.1",
-        "sade": "^1.8.1",
-        "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "@ipld/car": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.3.0.tgz",
-          "integrity": "sha512-OB8LVvJeVAFFGluNIkZeDZ/aGeoekFKsuIvNT9I5sJIb5WekQuW5+lekjQ7Z7mZ7DBKuke/kI4jBT1j0/akU1w==",
-          "requires": {
-            "@ipld/dag-cbor": "^9.0.7",
-            "cborg": "^4.0.5",
-            "multiformats": "^13.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "@ipld/dag-cbor": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
-          "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
-          "requires": {
-            "cborg": "^4.0.0",
-            "multiformats": "^13.1.0"
-          }
-        },
-        "@ipld/dag-pb": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
-          "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
-          "requires": {
-            "multiformats": "^13.1.0"
-          }
-        },
-        "@multiformats/murmur3": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
-          "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
-          "requires": {
-            "multiformats": "^13.0.0",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        },
-        "cborg": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
-          "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA=="
-        },
-        "hamt-sharding": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.6.tgz",
-          "integrity": "sha512-nZeamxfymIWLpVcAN0CRrb7uVq3hCOGj9IcL6NMA6VVCVWqj+h9Jo/SmaWuS92AEDf1thmHsM5D5c70hM3j2Tg==",
-          "requires": {
-            "sparse-array": "^1.3.1",
-            "uint8arrays": "^5.0.1"
-          }
-        },
-        "interface-blockstore": {
-          "version": "5.2.10",
-          "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.10.tgz",
-          "integrity": "sha512-9K48hTvBCGsKVD3pF4ILgDcf+W2P/gq0oxLcsHGB6E6W6nDutYkzR+7k7bCs9REHrBEfKzcVDEKieiuNM9WRZg==",
-          "requires": {
-            "interface-store": "^5.0.0",
-            "multiformats": "^13.0.1"
-          }
-        },
-        "interface-store": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
-          "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
-        },
-        "ipfs-unixfs": {
-          "version": "11.1.4",
-          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.4.tgz",
-          "integrity": "sha512-RE4nyx5qgG2w7JOLj0Y0D7SfAR1ZkEdramNaBx0OSD4DlQ2Y2NORgc4FHfej3Pgy31v+QISDVP1pQJhdv3bUUg==",
-          "requires": {
-            "err-code": "^3.0.1",
-            "protons-runtime": "^5.4.0",
-            "uint8arraylist": "^2.4.8"
-          }
-        },
-        "ipfs-unixfs-exporter": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-13.5.0.tgz",
-          "integrity": "sha512-s1eWXzoyhQFNEAB1p+QE3adjhW+lBdgpORmmjiCLiruHs5z7T5zsAgRVcWpM8LWYhq2flRtJHObb7Hg73J+oLQ==",
-          "requires": {
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ipld/dag-json": "^10.1.7",
-            "@ipld/dag-pb": "^4.0.0",
-            "@multiformats/murmur3": "^2.0.0",
-            "err-code": "^3.0.1",
-            "hamt-sharding": "^3.0.0",
-            "interface-blockstore": "^5.0.0",
-            "ipfs-unixfs": "^11.0.0",
-            "it-filter": "^3.0.2",
-            "it-last": "^3.0.2",
-            "it-map": "^3.0.3",
-            "it-parallel": "^3.0.0",
-            "it-pipe": "^3.0.1",
-            "it-pushable": "^3.1.0",
-            "multiformats": "^13.0.0",
-            "p-queue": "^8.0.1",
-            "progress-events": "^1.0.0"
-          }
-        },
-        "it-filter": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.4.tgz",
-          "integrity": "sha512-e0sz+st4sudK/zH6GZ/gRTRP8A/ADuJFCYDmRgMbZvR79y5+v4ZXav850bBZk5wL9zXaYZFxS1v/6Qi+Vjwh5g==",
-          "requires": {
-            "it-peekable": "^3.0.0"
-          }
-        },
-        "it-last": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.4.tgz",
-          "integrity": "sha512-Ns+KTsQWhs0KCvfv5X3Ck3lpoYxHcp4zUp4d+AOdmC8cXXqDuoZqAjfWhgCbxJubXyIYWdfE2nRcfWqgvZHP8Q=="
-        },
-        "it-map": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.5.tgz",
-          "integrity": "sha512-hB0TDXo/h4KSJJDSRLgAPmDroiXP6Fx1ck4Bzl3US9hHfZweTKsuiP0y4gXuTMcJlS6vj0bb+f70rhkD47ZA3w==",
-          "requires": {
-            "it-peekable": "^3.0.0"
-          }
-        },
-        "it-peekable": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.3.tgz",
-          "integrity": "sha512-Wx21JX/rMzTEl9flx3DGHuPV1KQFGOl8uoKfQtmZHgPQtGb89eQ6RyVd82h3HuP9Ghpt0WgBDlmmdWeHXqyx7w=="
-        },
-        "it-pipe": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
-          "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
-          "requires": {
-            "it-merge": "^3.0.0",
-            "it-pushable": "^3.1.2",
-            "it-stream-types": "^2.0.1"
-          }
-        },
-        "multiformats": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-        },
-        "uint8arrays": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
-          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
-          "requires": {
-            "multiformats": "^13.0.0"
-          }
-        }
-      }
-    },
     "ipfs-core-types": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.8.4.tgz",
@@ -5027,6 +5114,13 @@
         "interface-datastore": "^6.0.2",
         "multiaddr": "^10.0.0",
         "multiformats": "^9.4.13"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "ipfs-core-utils": {
@@ -5069,6 +5163,11 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        },
         "nanoid": {
           "version": "3.3.4",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -5110,6 +5209,11 @@
             "cborg": "^1.6.0",
             "multiformats": "^9.5.4"
           }
+        },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
         }
       }
     },
@@ -5133,6 +5237,13 @@
         "multiformats": "^9.4.2",
         "rabin-wasm": "^0.1.4",
         "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "ipfs-utils": {
@@ -5366,29 +5477,6 @@
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
       "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
     },
-    "it-merge": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.3.tgz",
-      "integrity": "sha512-FYVU15KC5pb/GQX1Ims+lee8d4pdqGVCpWr0lkNj8o4xuNo7jY71k6GuEiWdP+T7W1bJqewSxX5yoTy5yZpRVA==",
-      "requires": {
-        "it-pushable": "^3.2.0"
-      }
-    },
-    "it-parallel": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.6.tgz",
-      "integrity": "sha512-i7UM7I9LTkDJw3YIqXHFAPZX6CWYzGc+X3irdNrVExI4vPazrJdI7t5OqrSVN8CONXLAunCiqaSV/zZRbQR56A==",
-      "requires": {
-        "p-defer": "^4.0.0"
-      },
-      "dependencies": {
-        "p-defer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
-          "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="
-        }
-      }
-    },
     "it-parallel-batch": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.10.tgz",
@@ -5401,11 +5489,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
       "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
-    },
-    "it-pipe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
-      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
     },
     "it-pushable": {
       "version": "3.2.3",
@@ -5457,11 +5540,6 @@
         }
       }
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5476,6 +5554,179 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "kubo-rpc-client": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-4.1.1.tgz",
+      "integrity": "sha512-vxIkTQLvDqd2DEcBfz7DWegAidYtopmWUR/UhWyuuss9+JNFzV5neBn8BKxSDHoLJPvkxJpqXDaJhsb7ZuPouQ==",
+      "requires": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface": "^1.2.0",
+        "@libp2p/logger": "^4.0.10",
+        "@libp2p/peer-id": "^4.0.10",
+        "@multiformats/multiaddr": "^12.2.1",
+        "@multiformats/multiaddr-to-uri": "^10.0.1",
+        "any-signal": "^4.1.1",
+        "blob-to-it": "^2.0.5",
+        "browser-readablestream-to-it": "^2.0.5",
+        "dag-jose": "^5.0.0",
+        "electron-fetch": "^1.9.1",
+        "err-code": "^3.0.1",
+        "ipfs-unixfs": "^11.1.4",
+        "iso-url": "^1.2.1",
+        "it-all": "^3.0.4",
+        "it-first": "^3.0.4",
+        "it-glob": "^2.0.6",
+        "it-last": "^3.0.4",
+        "it-map": "^3.0.5",
+        "it-peekable": "^3.0.3",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "nanoid": "^5.0.7",
+        "native-fetch": "^4.0.2",
+        "parse-duration": "^1.0.2",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^1.0.1",
+        "uint8arrays": "^5.0.3",
+        "wherearewe": "^2.0.1"
+      },
+      "dependencies": {
+        "@ipld/dag-cbor": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+          "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
+          "requires": {
+            "cborg": "^4.0.0",
+            "multiformats": "^13.1.0"
+          }
+        },
+        "@ipld/dag-pb": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
+          "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
+          "requires": {
+            "multiformats": "^13.1.0"
+          }
+        },
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        },
+        "blob-to-it": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-2.0.5.tgz",
+          "integrity": "sha512-3VIFla8L4JuB+0WCdf+0POI7E1tTl8mhdGiwwwmnZEu6QjRJciS9fIvz8NgWY9URb0iagXYModGEYTcYeq9BMg==",
+          "requires": {
+            "browser-readablestream-to-it": "^2.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "browser-readablestream-to-it": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.5.tgz",
+          "integrity": "sha512-obLCT9jnxAeZlbaRWluUiZrcSJEoi2JkM0eoiJqlIP7MFwZwZjcB6giZvD343PXfr96ilD91M/wFqFvyAZq+Gg=="
+        },
+        "cborg": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.0.tgz",
+          "integrity": "sha512-q6cFW5m3KxfP/9xGI3yGLaC1l5DP6DWM9IvjiJojnIwohL5CQDl02EXViPV852mOfQo+7PJGPN01MI87vFGzyA=="
+        },
+        "ipfs-unixfs": {
+          "version": "11.1.4",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.4.tgz",
+          "integrity": "sha512-RE4nyx5qgG2w7JOLj0Y0D7SfAR1ZkEdramNaBx0OSD4DlQ2Y2NORgc4FHfej3Pgy31v+QISDVP1pQJhdv3bUUg==",
+          "requires": {
+            "err-code": "^3.0.1",
+            "protons-runtime": "^5.4.0",
+            "uint8arraylist": "^2.4.8"
+          }
+        },
+        "it-all": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.4.tgz",
+          "integrity": "sha512-UMiy0i9DqCHBdWvMbzdYvVGa5/w4t1cc4nchpbnjdLhklglv8mQeEYnii0gvKESJuL1zV32Cqdb33R6/GPfxpQ=="
+        },
+        "it-first": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.4.tgz",
+          "integrity": "sha512-FtQl84iTNxN5EItP/JgL28V2rzNMkCzTUlNoj41eVdfix2z1DBuLnBqZ0hzYhGGa1rMpbQf0M7CQSA2adlrLJg=="
+        },
+        "it-glob": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-2.0.6.tgz",
+          "integrity": "sha512-4C6ccz4nhqrq7yZMzBr3MsKhyL+rlnLXIPceyGG6ogl3Lx3eeWMv1RtlySJwFi6q+jVcPyTpeYt/xftwI2JEQQ==",
+          "requires": {
+            "minimatch": "^9.0.0"
+          }
+        },
+        "it-last": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.4.tgz",
+          "integrity": "sha512-Ns+KTsQWhs0KCvfv5X3Ck3lpoYxHcp4zUp4d+AOdmC8cXXqDuoZqAjfWhgCbxJubXyIYWdfE2nRcfWqgvZHP8Q=="
+        },
+        "it-map": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.5.tgz",
+          "integrity": "sha512-hB0TDXo/h4KSJJDSRLgAPmDroiXP6Fx1ck4Bzl3US9hHfZweTKsuiP0y4gXuTMcJlS6vj0bb+f70rhkD47ZA3w==",
+          "requires": {
+            "it-peekable": "^3.0.0"
+          }
+        },
+        "it-peekable": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.3.tgz",
+          "integrity": "sha512-Wx21JX/rMzTEl9flx3DGHuPV1KQFGOl8uoKfQtmZHgPQtGb89eQ6RyVd82h3HuP9Ghpt0WgBDlmmdWeHXqyx7w=="
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "native-fetch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
+          "requires": {}
+        },
+        "react-native-fetch-api": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+          "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+          "requires": {
+            "p-defer": "^3.0.0"
+          }
+        },
+        "stream-to-it": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-1.0.1.tgz",
+          "integrity": "sha512-AqHYAYPHcmvMrcLNgncE/q0Aj/ajP6A4qGhxP6EVn7K3YTNs0bJpJyk57wc2Heb7MUL64jurvmnmui8D9kjZgA==",
+          "requires": {
+            "it-stream-types": "^2.0.1"
+          }
+        },
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
+      }
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -5619,11 +5870,6 @@
         "path-exists": "^4.0.0"
       }
     },
-    "mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
-    },
     "mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -5659,6 +5905,13 @@
         "multiformats": "^9.4.5",
         "uint8arrays": "^3.0.0",
         "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "multiaddr-to-uri": {
@@ -5670,9 +5923,9 @@
       }
     },
     "multiformats": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.7.0.tgz",
-      "integrity": "sha512-uv/tcgwk0yN4DStopnBN4GTgvaAlYdy6KnZpuzEPFOYQd71DYFJjs0MN1ERElAflrZaYyGBWXyGxL5GgrxIx0Q=="
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -5721,6 +5974,27 @@
         "throttled-queue": "^2.1.2"
       },
       "dependencies": {
+        "@ipld/car": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.2.4.tgz",
+          "integrity": "sha512-rezKd+jk8AsTGOoJKqzfjLJ3WVft7NZNH95f0pfPbicROvzTyvHCNy567HzSUd6gRXZ9im29z5ZEv9Hw49jSYw==",
+          "requires": {
+            "@ipld/dag-cbor": "^7.0.0",
+            "multiformats": "^9.5.4",
+            "varint": "^6.0.0"
+          },
+          "dependencies": {
+            "@ipld/dag-cbor": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+              "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+              "requires": {
+                "cborg": "^1.6.0",
+                "multiformats": "^9.5.4"
+              }
+            }
+          }
+        },
         "ipfs-car": {
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.2.tgz",
@@ -5748,6 +6022,16 @@
             "streaming-iterables": "^6.0.0",
             "uint8arrays": "^3.0.0"
           }
+        },
+        "it-pipe": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
+          "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+        },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
         }
       }
     },
@@ -5894,6 +6178,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "prettier": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
@@ -5940,11 +6229,6 @@
         "uint8arrays": "^5.0.1"
       },
       "dependencies": {
-        "multiformats": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-        },
         "uint8arrays": {
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
@@ -5976,11 +6260,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
-    },
-    "rabin-rs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rabin-rs/-/rabin-rs-2.1.0.tgz",
-      "integrity": "sha512-5y72gAXPzIBsAMHcpxZP8eMDuDT98qMP1BqSDHRbHkJJXEgWIN1lA47LxUqzsK6jknOJtgfkQr9v+7qMlFDm6g=="
     },
     "rabin-wasm": {
       "version": "0.1.5",
@@ -6174,14 +6453,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
-    },
-    "sade": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "requires": {
-        "mri": "^1.1.0"
-      }
     },
     "safari-14-idb-fix": {
       "version": "3.0.0",
@@ -6423,11 +6694,6 @@
         "uint8arrays": "^5.0.0"
       },
       "dependencies": {
-        "multiformats": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-        },
         "uint8arrays": {
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
@@ -6446,11 +6712,6 @@
         "uint8arrays": "^5.0.1"
       },
       "dependencies": {
-        "multiformats": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
-        },
         "uint8arrays": {
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
@@ -6467,6 +6728,13 @@
       "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "requires": {
         "multiformats": "^9.4.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "unbox-primitive": {
@@ -6479,6 +6747,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.14.1.tgz",
+      "integrity": "sha512-mAel3i4BsYhkeVPXeIPXVGPJKeBzqCieZYoFsbWfUzd68JmHByhc1Plit5WlylxXFaGpgkZB8mExlxnt+Q1p7A==",
+      "peer": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -6507,6 +6781,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -6540,6 +6819,14 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
+    "wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "requires": {
+        "is-electron": "^2.2.0"
+      }
     },
     "which-boxed-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,18 +11,21 @@
   "author": "Simon Kusterer",
   "license": "MIT",
   "dependencies": {
+    "@ipld/car": "^5.3.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "ipfs-car": "^1.2.0",
+    "kubo-rpc-client": "^4.1.1",
     "multer": "^1.4.5-lts.1",
     "nanoid": "^5.0.7",
-    "nft.storage": "^7.1.1"
+    "nft.storage": "^7.1.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "prettier": "^3.2.5"
   },
   "engines": {
     "node": ">=16"
-  }
+  },
+  "type": "commonjs"
 }

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   "license": "MIT",
   "dependencies": {
     "cors": "^2.8.5",
-    "dotenv": "^16.0.1",
-    "express": "^4.18.1",
-    "ipfs-car": "^0.7.0",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "ipfs-car": "^1.2.0",
     "multer": "^1.4.5-lts.1",
-    "nanoid": "^4.0.0",
-    "nft.storage": "^6.4.1"
+    "nanoid": "^5.0.7",
+    "nft.storage": "^7.1.1"
   },
   "devDependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^3.2.5"
   },
   "engines": {
     "node": ">=16"

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4,7 +4,7 @@ import express from "express";
 import multer from "multer";
 import cors from "cors";
 import { nanoid } from "nanoid";
-import { unlink, mkdirSync, existsSync, createReadStream } from 'node:fs';
+import { mkdirSync, existsSync, createReadStream, rmSync } from 'node:fs';
 import path from "path"
 import { create, globSource } from 'kubo-rpc-client'
 import { randomUUID } from 'node:crypto';
@@ -73,12 +73,11 @@ app.post("/single", preuploadMiddleware, upload.single("asset"), async function 
       await NFTStorageClient.storeCar(await CarReader.fromIterable(carBlob))
     }
 
-    unlink(req.file.path, (err) => {
-      if (err) throw err;
-    })
     res.json({ cid: cid.toString() });
   } catch (err) {
     handle_error(res, req, `unexpected error calling /single endpoint: ${err}`);
+  } finally {
+    rmSync("./data/" + req.dest, {recursive: true, force: true})
   }
 });
 
@@ -102,6 +101,8 @@ app.post("/multiple", preuploadMiddleware, upload.array("assets", 2000), async f
     res.json({ cid: cid.toString() });
   } catch (err) {
     handle_error(res, req, `unexpected error calling /multiple endpoint: ${err}`);
+  } finally {
+    rmSync("./data/" + req.dest, {recursive: true, force: true})
   }
 });
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,19 +1,40 @@
 import "dotenv/config";
 import { File, NFTStorage } from "nft.storage";
-import { packToBlob } from "ipfs-car/pack/blob";
 import express from "express";
-import { Blob } from "buffer";
 import multer from "multer";
 import cors from "cors";
 import { nanoid } from "nanoid";
+import { unlink, mkdirSync, existsSync, createReadStream } from 'node:fs';
+import path from "path"
+import { create, globSource } from 'kubo-rpc-client'
+import { randomUUID } from 'node:crypto';
+import { CarReader } from '@ipld/car'
 
-const client = new NFTStorage({ token: process.env.API_TOKEN });
+const NFTStorageClient = new NFTStorage({ token: process.env.API_TOKEN });
 const port = process.env.PORT || 4444;
 const app = express();
 
 app.use(cors());
 
-const storage = multer.memoryStorage();
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    let path = './data/' + req.dest + '/';
+    file.path = path;
+    if (!existsSync(path, { recursive: true })) {
+      mkdirSync(path);
+    }
+    cb(null, path);
+  },
+  filename: function (req, file, cb) {
+    const parsed = path.parse(file.originalname)
+    const dest = './data/' + req.dest + '/' + parsed.dir
+    if (!existsSync(dest)) {
+      mkdirSync(dest, { recursive: true });
+    }
+    cb(null, file.originalname);
+  }
+})
+
 const upload = multer({
   storage,
   preservePath: true,
@@ -28,32 +49,55 @@ const handle_error = (res, req, error, status = 500) => {
   res.status(status).send(`${id} | ${error}`);
 };
 
-app.post("/single", upload.single("asset"), async function (req, res) {
+const kuboClient = await create({
+  host: process.env.IPFS_SERVER || '127.0.0.1',
+  port: 5001,
+  protocol: 'http',
+})
+
+const preuploadMiddleware = (req, _, next) => {
+  req.dest = randomUUID();
+  next();
+};
+
+app.post("/single", preuploadMiddleware, upload.single("asset"), async function (req, res) {
   try {
     if (req.file == null) {
       return handle_error(res, req, "Invalid request: 'file' is missing.", 400);
     }
 
-    const { root, car } = await packToBlob({
-      input: new Blob([req.file.buffer]),
-      rawLeaves: false,
-      wrapWithDirectory: false,
-    });
-    await client.storeCar(car);
-    const cid = root.toV0().toString();
+    const { cid } = await kuboClient.add(createReadStream(req.file.path), { cidVersion: 0, rawLeaves: false, wrapWithDirectory: false })
+    if (process.env.API_TOKEN && process.env.USE_NFTSTORAGE) {
+      console.log('uploading to nftstorage')
+      const carBlob = kuboClient.dag.export(cid)
+      await NFTStorageClient.storeCar(await CarReader.fromIterable(carBlob))
+    }
 
-    res.json({ cid });
+    unlink(req.file.path, (err) => {
+      if (err) throw err;
+    })
+    res.json({ cid: cid.toString() });
   } catch (err) {
     handle_error(res, req, `unexpected error calling /single endpoint: ${err}`);
   }
 });
 
-app.post("/multiple", upload.array("assets", 2000), async function (req, res) {
+app.post("/multiple", preuploadMiddleware, upload.array("assets", 2000), async function (req, res) {
   try {
     if (req.files == null || req.files.length == 0) {
       return handle_error(res, req, "Invalid request: 'files' is missing or empty.", 400);
     }
-    const cid = await client.storeDirectory(req.files.map((file) => new File([file.buffer], file.originalname)));
+
+    if (process.env.API_TOKEN && process.env.USE_NFTSTORAGE) {
+      console.log('uploading to nftstorage')
+      await NFTStorageClient.storeDirectory(req.files.map((file) => new File([file.buffer], file.originalname)));
+    }
+
+    let cid
+    for await (const file of kuboClient.addAll(globSource("./data/" + req.dest + "/", "**/*"), {wrapWithDirectory: true})) {
+      console.log(file)
+      cid = file.cid
+    }
 
     res.json({ cid: cid.toString() });
   } catch (err) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { File, NFTStorage } from "nft.storage";
+import { NFTStorage } from "nft.storage";
 import express from "express";
 import multer from "multer";
 import cors from "cors";


### PR DESCRIPTION
NFTStorage is pretty much kicking us out :sweat_smile: it's going to cost $3/GB starting from Jun 30:
[Important_updates_and_exciting_future_for_NFTStorage_users.pdf](https://github.com/teia-community/ipfs-upload-proxy/files/15082564/Important_updates_and_exciting_future_for_NFTStorage_users.pdf)

With this PR mints are uploaded to nftstorage and to a tiny ipfs node. Once the indexer sees the new mint, they get pinned permanently on the big machine.